### PR TITLE
Don't rely on jq in issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ labels: bug
 Inspect your go.mod as below to find the version, and paste the result between
 the ``` marks below.
 
-go list -m github.com/hashicorp/terraform-plugin-mux
+go list -m github.com/hashicorp/terraform-plugin-mux/...
 
 If you are not running the latest version of terraform-plugin-mux, please try
 upgrading because your bug may have already been fixed.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ labels: bug
 Inspect your go.mod as below to find the version, and paste the result between
 the ``` marks below.
 
-go mod edit -json | jq '.Require[] | select(.Path=="github.com/hashicorp/terraform-plugin-mux")'
+go list -m github.com/hashicorp/terraform-plugin-mux
 
 If you are not running the latest version of terraform-plugin-mux, please try
 upgrading because your bug may have already been fixed.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,7 +8,7 @@ labels: enhancement
 <!--
 Inspect your go.mod as below to find the version, and paste the result between the ``` marks below.
 
-go mod edit -json | jq '.Require[] | select(.Path=="github.com/hashicorp/terraform-plugin-mux")'
+go list -m github.com/hashicorp/terraform-plugin-mux
 
 If you are not running the latest version of terraform-plugin-mux, please try
 upgrading because your feature may have already been implemented.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,7 +8,7 @@ labels: enhancement
 <!--
 Inspect your go.mod as below to find the version, and paste the result between the ``` marks below.
 
-go list -m github.com/hashicorp/terraform-plugin-mux
+go list -m github.com/hashicorp/terraform-plugin-mux/...
 
 If you are not running the latest version of terraform-plugin-mux, please try
 upgrading because your feature may have already been implemented.


### PR DESCRIPTION
Use the built-in functionality in the `go` command to extract the
current module version in the issue template instructions, rather than
relying on `jq` parsing.