### PR TITLE
Refactor logging into shared internal package

### DIFF
--- a/internal/logging/context.go
+++ b/internal/logging/context.go
@@ -1,0 +1,27 @@
+package logging
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
+)
+
+// InitContext creates SDK logger contexts.
+func InitContext(ctx context.Context) context.Context {
+	ctx = tfsdklog.NewSubsystem(ctx, SubsystemMux, tfsdklog.WithLevelFromEnv(EnvTfLogSdkMux))
+
+	return ctx
+}
+
+// Tfprotov5ProviderServerContext injects the chosen provider Go type
+func Tfprotov5ProviderServerContext(ctx context.Context, p tfprotov5.ProviderServer) context.Context {
+	providerType := fmt.Sprintf("%T", p)
+	ctx = tflog.With(ctx, KeyTfMuxProvider, providerType)
+	ctx = tfsdklog.With(ctx, KeyTfMuxProvider, providerType)
+	ctx = tfsdklog.SubsystemWith(ctx, SubsystemMux, KeyTfMuxProvider, providerType)
+
+	return ctx
+}

--- a/internal/logging/doc.go
+++ b/internal/logging/doc.go
@@ -1,0 +1,2 @@
+// Package logging contains shared environment variable and log functionality.
+package logging

--- a/internal/logging/environment_variables.go
+++ b/internal/logging/environment_variables.go
@@ -1,0 +1,8 @@
+package logging
+
+// Environment variables.
+const (
+	// EnvTfLogSdkMux is an environment variable that sets the logging level
+	// of the mux logger. Infers root SDK logging level, if unset.
+	EnvTfLogSdkMux = "TF_LOG_SDK_MUX"
+)

--- a/internal/logging/keys.go
+++ b/internal/logging/keys.go
@@ -1,0 +1,10 @@
+package logging
+
+// Global logging keys attached to all requests.
+//
+// Practitioners or tooling reading logs may be depending on these keys, so be
+// conscious of that when changing them.
+const (
+	// Go type of the provider selected by mux.
+	KeyTfMuxProvider = "tf_mux_provider"
+)

--- a/internal/logging/mux.go
+++ b/internal/logging/mux.go
@@ -1,0 +1,17 @@
+package logging
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
+)
+
+const (
+	// SubsystemMux is the tfsdklog subsystem name for mux logging.
+	SubsystemMux = "mux"
+)
+
+// MuxTrace emits a mux subsystem log at TRACE level.
+func MuxTrace(ctx context.Context, msg string, args ...interface{}) {
+	tfsdklog.SubsystemTrace(ctx, SubsystemMux, msg, args)
+}


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/19
Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/33

In the near future, this project will be implementing multiple packages which will be reliant on shared logging details. Refactoring this code now will prevent duplication when those packages get created.

This logging package structure is similar to what is being implemented in terraform-plugin-go, not only for code consistency, but in the event that portions or all of this project is subsumed into that project.