### PR TITLE
Introduce tf5to6server and tf6to5server packages

### DIFF
--- a/.changelog/42.txt
+++ b/.changelog/42.txt
@@ -1,0 +1,11 @@
+```release-note:note
+Providers can now be muxed with a combination of terraform-plugin-sdk and terraform-plugin-framework server implementations. One option is the terraform-plugin-sdk server can be upgraded to protocol version 6, then muxed with the terraform-plugin-framework server. This allows using new protocol features in the framework implementation, such as nested attributes, but requires Terraform CLI 1.1.5 or later. The other option is the terraform-plugin-framework server can be downgraded to protocol version 5, then muxed with the terraform-plugin-sdk server. This prevents using new protocol features in the framework implementation, however it remains compatible with Terraform CLI 0.12 and later.
+```
+
+```release-note:feature
+Added `tf5to6server` package, for upgrading a protocol version 5 server to protocol version 6
+```
+
+```release-note:feature
+Added `tf6to5server` package, for downgrading a protocol version 6 server to protocol version 5
+```

--- a/internal/tf5testserver/tf5testserver.go
+++ b/internal/tf5testserver/tf5testserver.go
@@ -18,6 +18,8 @@ type TestServer struct {
 
 	ConfigureProviderCalled bool
 
+	GetProviderSchemaCalled bool
+
 	ImportResourceStateCalled map[string]bool
 
 	PlanResourceChangeCalled map[string]bool
@@ -58,6 +60,8 @@ func (s *TestServer) ConfigureProvider(_ context.Context, _ *tfprotov5.Configure
 }
 
 func (s *TestServer) GetProviderSchema(_ context.Context, _ *tfprotov5.GetProviderSchemaRequest) (*tfprotov5.GetProviderSchemaResponse, error) {
+	s.GetProviderSchemaCalled = true
+
 	if s.DataSourceSchemas == nil {
 		s.DataSourceSchemas = make(map[string]*tfprotov5.Schema)
 	}

--- a/internal/tf6testserver/tf6testserver.go
+++ b/internal/tf6testserver/tf6testserver.go
@@ -18,6 +18,8 @@ type TestServer struct {
 
 	ConfigureProviderCalled bool
 
+	GetProviderSchemaCalled bool
+
 	ImportResourceStateCalled map[string]bool
 
 	PlanResourceChangeCalled map[string]bool
@@ -58,6 +60,8 @@ func (s *TestServer) ConfigureProvider(_ context.Context, _ *tfprotov6.Configure
 }
 
 func (s *TestServer) GetProviderSchema(_ context.Context, _ *tfprotov6.GetProviderSchemaRequest) (*tfprotov6.GetProviderSchemaResponse, error) {
+	s.GetProviderSchemaCalled = true
+
 	if s.DataSourceSchemas == nil {
 		s.DataSourceSchemas = make(map[string]*tfprotov6.Schema)
 	}

--- a/internal/tfprotov5tov6/tfprotov5tov6.go
+++ b/internal/tfprotov5tov6/tfprotov5tov6.go
@@ -1,0 +1,442 @@
+package tfprotov5tov6
+
+import (
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+func ApplyResourceChangeRequest(in *tfprotov5.ApplyResourceChangeRequest) *tfprotov6.ApplyResourceChangeRequest {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.ApplyResourceChangeRequest{
+		Config:         DynamicValue(in.Config),
+		PlannedPrivate: in.PlannedPrivate,
+		PlannedState:   DynamicValue(in.PlannedState),
+		PriorState:     DynamicValue(in.PriorState),
+		ProviderMeta:   DynamicValue(in.ProviderMeta),
+		TypeName:       in.TypeName,
+	}
+}
+
+func ApplyResourceChangeResponse(in *tfprotov5.ApplyResourceChangeResponse) *tfprotov6.ApplyResourceChangeResponse {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.ApplyResourceChangeResponse{
+		Diagnostics:                 Diagnostics(in.Diagnostics),
+		NewState:                    DynamicValue(in.NewState),
+		Private:                     in.Private,
+		UnsafeToUseLegacyTypeSystem: in.UnsafeToUseLegacyTypeSystem, //nolint:staticcheck
+	}
+}
+
+func ConfigureProviderRequest(in *tfprotov5.ConfigureProviderRequest) *tfprotov6.ConfigureProviderRequest {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.ConfigureProviderRequest{
+		Config:           DynamicValue(in.Config),
+		TerraformVersion: in.TerraformVersion,
+	}
+}
+
+func ConfigureProviderResponse(in *tfprotov5.ConfigureProviderResponse) *tfprotov6.ConfigureProviderResponse {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.ConfigureProviderResponse{
+		Diagnostics: Diagnostics(in.Diagnostics),
+	}
+}
+
+func Diagnostics(in []*tfprotov5.Diagnostic) []*tfprotov6.Diagnostic {
+	if in == nil {
+		return nil
+	}
+
+	diags := make([]*tfprotov6.Diagnostic, 0, len(in))
+
+	for _, diag := range in {
+		if diag == nil {
+			diags = append(diags, nil)
+			continue
+		}
+
+		diags = append(diags, &tfprotov6.Diagnostic{
+			Severity:  tfprotov6.DiagnosticSeverity(diag.Severity),
+			Summary:   diag.Summary,
+			Detail:    diag.Detail,
+			Attribute: diag.Attribute,
+		})
+	}
+
+	return diags
+}
+
+func DynamicValue(in *tfprotov5.DynamicValue) *tfprotov6.DynamicValue {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.DynamicValue{
+		MsgPack: in.MsgPack,
+		JSON:    in.JSON,
+	}
+}
+
+func GetProviderSchemaRequest(in *tfprotov5.GetProviderSchemaRequest) *tfprotov6.GetProviderSchemaRequest {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.GetProviderSchemaRequest{}
+}
+
+func GetProviderSchemaResponse(in *tfprotov5.GetProviderSchemaResponse) *tfprotov6.GetProviderSchemaResponse {
+	if in == nil {
+		return nil
+	}
+
+	dataSourceSchemas := make(map[string]*tfprotov6.Schema, len(in.DataSourceSchemas))
+
+	for k, v := range in.DataSourceSchemas {
+		dataSourceSchemas[k] = Schema(v)
+	}
+
+	resourceSchemas := make(map[string]*tfprotov6.Schema, len(in.ResourceSchemas))
+
+	for k, v := range in.ResourceSchemas {
+		resourceSchemas[k] = Schema(v)
+	}
+
+	return &tfprotov6.GetProviderSchemaResponse{
+		DataSourceSchemas: dataSourceSchemas,
+		Diagnostics:       Diagnostics(in.Diagnostics),
+		Provider:          Schema(in.Provider),
+		ProviderMeta:      Schema(in.ProviderMeta),
+		ResourceSchemas:   resourceSchemas,
+	}
+}
+
+func ImportResourceStateRequest(in *tfprotov5.ImportResourceStateRequest) *tfprotov6.ImportResourceStateRequest {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.ImportResourceStateRequest{
+		ID:       in.ID,
+		TypeName: in.TypeName,
+	}
+}
+
+func ImportResourceStateResponse(in *tfprotov5.ImportResourceStateResponse) *tfprotov6.ImportResourceStateResponse {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.ImportResourceStateResponse{
+		Diagnostics:       Diagnostics(in.Diagnostics),
+		ImportedResources: ImportedResources(in.ImportedResources),
+	}
+}
+
+func ImportedResources(in []*tfprotov5.ImportedResource) []*tfprotov6.ImportedResource {
+	if in == nil {
+		return nil
+	}
+
+	res := make([]*tfprotov6.ImportedResource, 0, len(in))
+
+	for _, imp := range in {
+		if imp == nil {
+			res = append(res, nil)
+			continue
+		}
+
+		res = append(res, &tfprotov6.ImportedResource{
+			Private:  imp.Private,
+			State:    DynamicValue(imp.State),
+			TypeName: imp.TypeName,
+		})
+	}
+
+	return res
+}
+
+func PlanResourceChangeRequest(in *tfprotov5.PlanResourceChangeRequest) *tfprotov6.PlanResourceChangeRequest {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.PlanResourceChangeRequest{
+		Config:           DynamicValue(in.Config),
+		PriorPrivate:     in.PriorPrivate,
+		PriorState:       DynamicValue(in.PriorState),
+		ProposedNewState: DynamicValue(in.ProposedNewState),
+		ProviderMeta:     DynamicValue(in.ProviderMeta),
+		TypeName:         in.TypeName,
+	}
+}
+
+func PlanResourceChangeResponse(in *tfprotov5.PlanResourceChangeResponse) *tfprotov6.PlanResourceChangeResponse {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.PlanResourceChangeResponse{
+		Diagnostics:                 Diagnostics(in.Diagnostics),
+		PlannedPrivate:              in.PlannedPrivate,
+		PlannedState:                DynamicValue(in.PlannedState),
+		RequiresReplace:             in.RequiresReplace,
+		UnsafeToUseLegacyTypeSystem: in.UnsafeToUseLegacyTypeSystem, //nolint:staticcheck
+	}
+}
+
+func RawState(in *tfprotov5.RawState) *tfprotov6.RawState {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.RawState{
+		Flatmap: in.Flatmap,
+		JSON:    in.JSON,
+	}
+}
+
+func ReadDataSourceRequest(in *tfprotov5.ReadDataSourceRequest) *tfprotov6.ReadDataSourceRequest {
+	if in == nil {
+		return nil
+	}
+	return &tfprotov6.ReadDataSourceRequest{
+		Config:       DynamicValue(in.Config),
+		ProviderMeta: DynamicValue(in.ProviderMeta),
+		TypeName:     in.TypeName,
+	}
+}
+
+func ReadDataSourceResponse(in *tfprotov5.ReadDataSourceResponse) *tfprotov6.ReadDataSourceResponse {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.ReadDataSourceResponse{
+		Diagnostics: Diagnostics(in.Diagnostics),
+		State:       DynamicValue(in.State),
+	}
+}
+
+func ReadResourceRequest(in *tfprotov5.ReadResourceRequest) *tfprotov6.ReadResourceRequest {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.ReadResourceRequest{
+		CurrentState: DynamicValue(in.CurrentState),
+		Private:      in.Private,
+		ProviderMeta: DynamicValue(in.ProviderMeta),
+		TypeName:     in.TypeName,
+	}
+}
+
+func ReadResourceResponse(in *tfprotov5.ReadResourceResponse) *tfprotov6.ReadResourceResponse {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.ReadResourceResponse{
+		Diagnostics: Diagnostics(in.Diagnostics),
+		NewState:    DynamicValue(in.NewState),
+		Private:     in.Private,
+	}
+}
+
+func Schema(in *tfprotov5.Schema) *tfprotov6.Schema {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.Schema{
+		Block:   SchemaBlock(in.Block),
+		Version: in.Version,
+	}
+}
+
+func SchemaAttribute(in *tfprotov5.SchemaAttribute) *tfprotov6.SchemaAttribute {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.SchemaAttribute{
+		Computed:        in.Computed,
+		Deprecated:      in.Deprecated,
+		Description:     in.Description,
+		DescriptionKind: StringKind(in.DescriptionKind),
+		Name:            in.Name,
+		Optional:        in.Optional,
+		Required:        in.Required,
+		Sensitive:       in.Sensitive,
+		Type:            in.Type,
+	}
+}
+
+func SchemaBlock(in *tfprotov5.SchemaBlock) *tfprotov6.SchemaBlock {
+	if in == nil {
+		return nil
+	}
+
+	var attrs []*tfprotov6.SchemaAttribute
+
+	if in.Attributes != nil {
+		attrs = make([]*tfprotov6.SchemaAttribute, 0, len(in.Attributes))
+
+		for _, attr := range in.Attributes {
+			attrs = append(attrs, SchemaAttribute(attr))
+		}
+	}
+
+	var nestedBlocks []*tfprotov6.SchemaNestedBlock
+
+	if in.BlockTypes != nil {
+		nestedBlocks = make([]*tfprotov6.SchemaNestedBlock, 0, len(in.BlockTypes))
+
+		for _, block := range in.BlockTypes {
+			nestedBlocks = append(nestedBlocks, SchemaNestedBlock(block))
+		}
+	}
+
+	return &tfprotov6.SchemaBlock{
+		Attributes:      attrs,
+		BlockTypes:      nestedBlocks,
+		Deprecated:      in.Deprecated,
+		Description:     in.Description,
+		DescriptionKind: StringKind(in.DescriptionKind),
+		Version:         in.Version,
+	}
+}
+
+func SchemaNestedBlock(in *tfprotov5.SchemaNestedBlock) *tfprotov6.SchemaNestedBlock {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.SchemaNestedBlock{
+		Block:    SchemaBlock(in.Block),
+		MaxItems: in.MaxItems,
+		MinItems: in.MinItems,
+		Nesting:  tfprotov6.SchemaNestedBlockNestingMode(in.Nesting),
+		TypeName: in.TypeName,
+	}
+}
+
+func StopProviderRequest(in *tfprotov5.StopProviderRequest) *tfprotov6.StopProviderRequest {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.StopProviderRequest{}
+}
+
+func StopProviderResponse(in *tfprotov5.StopProviderResponse) *tfprotov6.StopProviderResponse {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.StopProviderResponse{
+		Error: in.Error,
+	}
+}
+
+func StringKind(in tfprotov5.StringKind) tfprotov6.StringKind {
+	return tfprotov6.StringKind(in)
+}
+
+func UpgradeResourceStateRequest(in *tfprotov5.UpgradeResourceStateRequest) *tfprotov6.UpgradeResourceStateRequest {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.UpgradeResourceStateRequest{
+		RawState: RawState(in.RawState),
+		TypeName: in.TypeName,
+		Version:  in.Version,
+	}
+}
+
+func UpgradeResourceStateResponse(in *tfprotov5.UpgradeResourceStateResponse) *tfprotov6.UpgradeResourceStateResponse {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.UpgradeResourceStateResponse{
+		Diagnostics:   Diagnostics(in.Diagnostics),
+		UpgradedState: DynamicValue(in.UpgradedState),
+	}
+}
+
+func ValidateDataResourceConfigRequest(in *tfprotov5.ValidateDataSourceConfigRequest) *tfprotov6.ValidateDataResourceConfigRequest {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.ValidateDataResourceConfigRequest{
+		Config:   DynamicValue(in.Config),
+		TypeName: in.TypeName,
+	}
+}
+
+func ValidateDataResourceConfigResponse(in *tfprotov5.ValidateDataSourceConfigResponse) *tfprotov6.ValidateDataResourceConfigResponse {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.ValidateDataResourceConfigResponse{
+		Diagnostics: Diagnostics(in.Diagnostics),
+	}
+}
+
+func ValidateProviderConfigRequest(in *tfprotov5.PrepareProviderConfigRequest) *tfprotov6.ValidateProviderConfigRequest {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.ValidateProviderConfigRequest{
+		Config: DynamicValue(in.Config),
+	}
+}
+
+func ValidateProviderConfigResponse(in *tfprotov5.PrepareProviderConfigResponse) *tfprotov6.ValidateProviderConfigResponse {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.ValidateProviderConfigResponse{
+		Diagnostics:    Diagnostics(in.Diagnostics),
+		PreparedConfig: DynamicValue(in.PreparedConfig),
+	}
+}
+
+func ValidateResourceConfigRequest(in *tfprotov5.ValidateResourceTypeConfigRequest) *tfprotov6.ValidateResourceConfigRequest {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.ValidateResourceConfigRequest{
+		Config:   DynamicValue(in.Config),
+		TypeName: in.TypeName,
+	}
+}
+
+func ValidateResourceConfigResponse(in *tfprotov5.ValidateResourceTypeConfigResponse) *tfprotov6.ValidateResourceConfigResponse {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.ValidateResourceConfigResponse{
+		Diagnostics: Diagnostics(in.Diagnostics),
+	}
+}

--- a/internal/tfprotov5tov6/tfprotov5tov6_test.go
+++ b/internal/tfprotov5tov6/tfprotov5tov6_test.go
@@ -1,0 +1,1490 @@
+package tfprotov5tov6_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-plugin-mux/internal/tfprotov5tov6"
+)
+
+var (
+	testBytes []byte = []byte("test")
+
+	testTfprotov5Diagnostics []*tfprotov5.Diagnostic = []*tfprotov5.Diagnostic{
+		{
+			Detail:   "test detail",
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "test summary",
+		},
+	}
+	testTfprotov6Diagnostics []*tfprotov6.Diagnostic = []*tfprotov6.Diagnostic{
+		{
+			Detail:   "test detail",
+			Severity: tfprotov6.DiagnosticSeverityError,
+			Summary:  "test summary",
+		},
+	}
+
+	testTfprotov5DynamicValue tfprotov5.DynamicValue
+	testTfprotov6DynamicValue tfprotov6.DynamicValue
+
+	testTfprotov5Schema *tfprotov5.Schema = &tfprotov5.Schema{
+		Block: &tfprotov5.SchemaBlock{
+			Attributes: []*tfprotov5.SchemaAttribute{
+				{
+					Name:     "test",
+					Required: true,
+				},
+			},
+			Version: 1,
+		},
+		Version: 1,
+	}
+	testTfprotov6Schema *tfprotov6.Schema = &tfprotov6.Schema{
+		Block: &tfprotov6.SchemaBlock{
+			Attributes: []*tfprotov6.SchemaAttribute{
+				{
+					Name:     "test",
+					Required: true,
+				},
+			},
+			Version: 1,
+		},
+		Version: 1,
+	}
+)
+
+func init() {
+	testTfprotov5DynamicValue, _ = tfprotov5.NewDynamicValue(tftypes.String, tftypes.NewValue(tftypes.String, "test"))
+	testTfprotov6DynamicValue, _ = tfprotov6.NewDynamicValue(tftypes.String, tftypes.NewValue(tftypes.String, "test"))
+}
+
+func TestApplyResourceChangeRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.ApplyResourceChangeRequest
+		expected *tfprotov6.ApplyResourceChangeRequest
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.ApplyResourceChangeRequest{
+				Config:         &testTfprotov5DynamicValue,
+				PlannedPrivate: testBytes,
+				PlannedState:   &testTfprotov5DynamicValue,
+				PriorState:     &testTfprotov5DynamicValue,
+				ProviderMeta:   &testTfprotov5DynamicValue,
+				TypeName:       "test",
+			},
+			expected: &tfprotov6.ApplyResourceChangeRequest{
+				Config:         &testTfprotov6DynamicValue,
+				PlannedPrivate: testBytes,
+				PlannedState:   &testTfprotov6DynamicValue,
+				PriorState:     &testTfprotov6DynamicValue,
+				ProviderMeta:   &testTfprotov6DynamicValue,
+				TypeName:       "test",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.ApplyResourceChangeRequest(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestApplyResourceChangeResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.ApplyResourceChangeResponse
+		expected *tfprotov6.ApplyResourceChangeResponse
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.ApplyResourceChangeResponse{
+				Diagnostics:                 testTfprotov5Diagnostics,
+				NewState:                    &testTfprotov5DynamicValue,
+				Private:                     testBytes,
+				UnsafeToUseLegacyTypeSystem: true,
+			},
+			expected: &tfprotov6.ApplyResourceChangeResponse{
+				Diagnostics:                 testTfprotov6Diagnostics,
+				NewState:                    &testTfprotov6DynamicValue,
+				Private:                     testBytes,
+				UnsafeToUseLegacyTypeSystem: true,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.ApplyResourceChangeResponse(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestConfigureProviderRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.ConfigureProviderRequest
+		expected *tfprotov6.ConfigureProviderRequest
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.ConfigureProviderRequest{
+				Config:           &testTfprotov5DynamicValue,
+				TerraformVersion: "1.2.3",
+			},
+			expected: &tfprotov6.ConfigureProviderRequest{
+				Config:           &testTfprotov6DynamicValue,
+				TerraformVersion: "1.2.3",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.ConfigureProviderRequest(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestConfigureProviderResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.ConfigureProviderResponse
+		expected *tfprotov6.ConfigureProviderResponse
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.ConfigureProviderResponse{
+				Diagnostics: testTfprotov5Diagnostics,
+			},
+			expected: &tfprotov6.ConfigureProviderResponse{
+				Diagnostics: testTfprotov6Diagnostics,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.ConfigureProviderResponse(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       []*tfprotov5.Diagnostic
+		expected []*tfprotov6.Diagnostic
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"empty": {
+			in:       []*tfprotov5.Diagnostic{},
+			expected: []*tfprotov6.Diagnostic{},
+		},
+		"one": {
+			in:       testTfprotov5Diagnostics,
+			expected: testTfprotov6Diagnostics,
+		},
+		"multiple": {
+			in: []*tfprotov5.Diagnostic{
+				{
+					Detail:   "test detail 1",
+					Severity: tfprotov5.DiagnosticSeverityError,
+					Summary:  "test summary 2",
+				},
+				{
+					Detail:   "test detail 1",
+					Severity: tfprotov5.DiagnosticSeverityError,
+					Summary:  "test summary 2",
+				},
+			},
+			expected: []*tfprotov6.Diagnostic{
+				{
+					Detail:   "test detail 1",
+					Severity: tfprotov6.DiagnosticSeverityError,
+					Summary:  "test summary 2",
+				},
+				{
+					Detail:   "test detail 1",
+					Severity: tfprotov6.DiagnosticSeverityError,
+					Summary:  "test summary 2",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.Diagnostics(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestDynamicValue(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.DynamicValue
+		expected *tfprotov6.DynamicValue
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.DynamicValue{
+				JSON:    testBytes,
+				MsgPack: testBytes,
+			},
+			expected: &tfprotov6.DynamicValue{
+				JSON:    testBytes,
+				MsgPack: testBytes,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.DynamicValue(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestGetProviderSchemaRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.GetProviderSchemaRequest
+		expected *tfprotov6.GetProviderSchemaRequest
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in:       &tfprotov5.GetProviderSchemaRequest{},
+			expected: &tfprotov6.GetProviderSchemaRequest{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.GetProviderSchemaRequest(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestGetProviderSchemaResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.GetProviderSchemaResponse
+		expected *tfprotov6.GetProviderSchemaResponse
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov5.Schema{
+					"test_data_source": testTfprotov5Schema,
+				},
+				Diagnostics:  testTfprotov5Diagnostics,
+				Provider:     testTfprotov5Schema,
+				ProviderMeta: testTfprotov5Schema,
+				ResourceSchemas: map[string]*tfprotov5.Schema{
+					"test_resource": testTfprotov5Schema,
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": testTfprotov6Schema,
+				},
+				Diagnostics:  testTfprotov6Diagnostics,
+				Provider:     testTfprotov6Schema,
+				ProviderMeta: testTfprotov6Schema,
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": testTfprotov6Schema,
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.GetProviderSchemaResponse(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestImportResourceStateRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.ImportResourceStateRequest
+		expected *tfprotov6.ImportResourceStateRequest
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.ImportResourceStateRequest{
+				ID:       "test-id",
+				TypeName: "test_resource",
+			},
+			expected: &tfprotov6.ImportResourceStateRequest{
+				ID:       "test-id",
+				TypeName: "test_resource",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.ImportResourceStateRequest(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestImportResourceStateResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.ImportResourceStateResponse
+		expected *tfprotov6.ImportResourceStateResponse
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.ImportResourceStateResponse{
+				Diagnostics: testTfprotov5Diagnostics,
+				ImportedResources: []*tfprotov5.ImportedResource{
+					{
+						Private:  testBytes,
+						State:    &testTfprotov5DynamicValue,
+						TypeName: "test_resource1",
+					},
+				},
+			},
+			expected: &tfprotov6.ImportResourceStateResponse{
+				Diagnostics: testTfprotov6Diagnostics,
+				ImportedResources: []*tfprotov6.ImportedResource{
+					{
+						Private:  testBytes,
+						State:    &testTfprotov6DynamicValue,
+						TypeName: "test_resource1",
+					},
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.ImportResourceStateResponse(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestImportedResources(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       []*tfprotov5.ImportedResource
+		expected []*tfprotov6.ImportedResource
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"empty": {
+			in:       []*tfprotov5.ImportedResource{},
+			expected: []*tfprotov6.ImportedResource{},
+		},
+		"one": {
+			in: []*tfprotov5.ImportedResource{
+				{
+					Private:  testBytes,
+					State:    &testTfprotov5DynamicValue,
+					TypeName: "test_resource1",
+				},
+			},
+			expected: []*tfprotov6.ImportedResource{
+				{
+					Private:  testBytes,
+					State:    &testTfprotov6DynamicValue,
+					TypeName: "test_resource1",
+				},
+			},
+		},
+
+		"multiple": {
+			in: []*tfprotov5.ImportedResource{
+				{
+					Private:  testBytes,
+					State:    &testTfprotov5DynamicValue,
+					TypeName: "test_resource1",
+				},
+				{
+					Private:  testBytes,
+					State:    &testTfprotov5DynamicValue,
+					TypeName: "test_resource2",
+				},
+			},
+			expected: []*tfprotov6.ImportedResource{
+				{
+					Private:  testBytes,
+					State:    &testTfprotov6DynamicValue,
+					TypeName: "test_resource1",
+				},
+				{
+					Private:  testBytes,
+					State:    &testTfprotov6DynamicValue,
+					TypeName: "test_resource2",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.ImportedResources(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestPlanResourceChangeRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.PlanResourceChangeRequest
+		expected *tfprotov6.PlanResourceChangeRequest
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.PlanResourceChangeRequest{
+				Config:           &testTfprotov5DynamicValue,
+				PriorPrivate:     testBytes,
+				PriorState:       &testTfprotov5DynamicValue,
+				ProposedNewState: &testTfprotov5DynamicValue,
+				ProviderMeta:     &testTfprotov5DynamicValue,
+				TypeName:         "test_resource",
+			},
+			expected: &tfprotov6.PlanResourceChangeRequest{
+				Config:           &testTfprotov6DynamicValue,
+				PriorPrivate:     testBytes,
+				PriorState:       &testTfprotov6DynamicValue,
+				ProposedNewState: &testTfprotov6DynamicValue,
+				ProviderMeta:     &testTfprotov6DynamicValue,
+				TypeName:         "test_resource",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.PlanResourceChangeRequest(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestPlanResourceChangeResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.PlanResourceChangeResponse
+		expected *tfprotov6.PlanResourceChangeResponse
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.PlanResourceChangeResponse{
+				Diagnostics:    testTfprotov5Diagnostics,
+				PlannedPrivate: testBytes,
+				PlannedState:   &testTfprotov5DynamicValue,
+				RequiresReplace: []*tftypes.AttributePath{
+					tftypes.NewAttributePath().WithAttributeName("test"),
+				},
+				UnsafeToUseLegacyTypeSystem: true,
+			},
+			expected: &tfprotov6.PlanResourceChangeResponse{
+				Diagnostics:    testTfprotov6Diagnostics,
+				PlannedPrivate: testBytes,
+				PlannedState:   &testTfprotov6DynamicValue,
+				RequiresReplace: []*tftypes.AttributePath{
+					tftypes.NewAttributePath().WithAttributeName("test"),
+				},
+				UnsafeToUseLegacyTypeSystem: true,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.PlanResourceChangeResponse(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestRawState(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.RawState
+		expected *tfprotov6.RawState
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.RawState{
+				Flatmap: map[string]string{"testkey": "testvalue"},
+				JSON:    testBytes,
+			},
+			expected: &tfprotov6.RawState{
+				Flatmap: map[string]string{"testkey": "testvalue"},
+				JSON:    testBytes,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.RawState(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestReadDataSourceRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.ReadDataSourceRequest
+		expected *tfprotov6.ReadDataSourceRequest
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.ReadDataSourceRequest{
+				Config:       &testTfprotov5DynamicValue,
+				ProviderMeta: &testTfprotov5DynamicValue,
+				TypeName:     "test_data_source",
+			},
+			expected: &tfprotov6.ReadDataSourceRequest{
+				Config:       &testTfprotov6DynamicValue,
+				ProviderMeta: &testTfprotov6DynamicValue,
+				TypeName:     "test_data_source",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.ReadDataSourceRequest(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestReadDataSourceResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.ReadDataSourceResponse
+		expected *tfprotov6.ReadDataSourceResponse
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.ReadDataSourceResponse{
+				Diagnostics: testTfprotov5Diagnostics,
+				State:       &testTfprotov5DynamicValue,
+			},
+			expected: &tfprotov6.ReadDataSourceResponse{
+				Diagnostics: testTfprotov6Diagnostics,
+				State:       &testTfprotov6DynamicValue,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.ReadDataSourceResponse(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestReadResourceRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.ReadResourceRequest
+		expected *tfprotov6.ReadResourceRequest
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.ReadResourceRequest{
+				CurrentState: &testTfprotov5DynamicValue,
+				Private:      testBytes,
+				ProviderMeta: &testTfprotov5DynamicValue,
+				TypeName:     "test_resource",
+			},
+			expected: &tfprotov6.ReadResourceRequest{
+				CurrentState: &testTfprotov6DynamicValue,
+				Private:      testBytes,
+				ProviderMeta: &testTfprotov6DynamicValue,
+				TypeName:     "test_resource",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.ReadResourceRequest(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestReadResourceResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.ReadResourceResponse
+		expected *tfprotov6.ReadResourceResponse
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.ReadResourceResponse{
+				Diagnostics: testTfprotov5Diagnostics,
+				NewState:    &testTfprotov5DynamicValue,
+				Private:     testBytes,
+			},
+			expected: &tfprotov6.ReadResourceResponse{
+				Diagnostics: testTfprotov6Diagnostics,
+				NewState:    &testTfprotov6DynamicValue,
+				Private:     testBytes,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.ReadResourceResponse(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSchema(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.Schema
+		expected *tfprotov6.Schema
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in:       testTfprotov5Schema,
+			expected: testTfprotov6Schema,
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.Schema(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSchemaAttribute(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.SchemaAttribute
+		expected *tfprotov6.SchemaAttribute
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.SchemaAttribute{
+				Computed:        true,
+				Deprecated:      true,
+				Description:     "test description",
+				DescriptionKind: tfprotov5.StringKindPlain,
+				Name:            "test",
+				Optional:        true,
+				Required:        true,
+				Sensitive:       true,
+				Type:            tftypes.String,
+			},
+			expected: &tfprotov6.SchemaAttribute{
+				Computed:        true,
+				Deprecated:      true,
+				Description:     "test description",
+				DescriptionKind: tfprotov6.StringKindPlain,
+				Name:            "test",
+				Optional:        true,
+				Required:        true,
+				Sensitive:       true,
+				Type:            tftypes.String,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.SchemaAttribute(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSchemaBlock(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.SchemaBlock
+		expected *tfprotov6.SchemaBlock
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.SchemaBlock{
+				Attributes: []*tfprotov5.SchemaAttribute{
+					{
+						Name:     "test_attribute",
+						Required: true,
+					},
+				},
+				BlockTypes: []*tfprotov5.SchemaNestedBlock{
+					{
+						Block: &tfprotov5.SchemaBlock{
+							Attributes: []*tfprotov5.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+								},
+							},
+						},
+						TypeName: "test_block",
+					},
+				},
+				Deprecated:      true,
+				Description:     "test description",
+				DescriptionKind: tfprotov5.StringKindPlain,
+				Version:         1,
+			},
+			expected: &tfprotov6.SchemaBlock{
+				Attributes: []*tfprotov6.SchemaAttribute{
+					{
+						Name:     "test_attribute",
+						Required: true,
+					},
+				},
+				BlockTypes: []*tfprotov6.SchemaNestedBlock{
+					{
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+								},
+							},
+						},
+						TypeName: "test_block",
+					},
+				},
+				Deprecated:      true,
+				Description:     "test description",
+				DescriptionKind: tfprotov6.StringKindPlain,
+				Version:         1,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.SchemaBlock(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSchemaNestedBlock(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.SchemaNestedBlock
+		expected *tfprotov6.SchemaNestedBlock
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.SchemaNestedBlock{
+				Block: &tfprotov5.SchemaBlock{
+					Attributes: []*tfprotov5.SchemaAttribute{
+						{
+							Name:     "test_attribute",
+							Required: true,
+						},
+					},
+				},
+				MaxItems: 1,
+				MinItems: 1,
+				Nesting:  tfprotov5.SchemaNestedBlockNestingModeList,
+				TypeName: "test_block",
+			},
+			expected: &tfprotov6.SchemaNestedBlock{
+				Block: &tfprotov6.SchemaBlock{
+					Attributes: []*tfprotov6.SchemaAttribute{
+						{
+							Name:     "test_attribute",
+							Required: true,
+						},
+					},
+				},
+				MaxItems: 1,
+				MinItems: 1,
+				Nesting:  tfprotov6.SchemaNestedBlockNestingModeList,
+				TypeName: "test_block",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.SchemaNestedBlock(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestStopProviderRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.StopProviderRequest
+		expected *tfprotov6.StopProviderRequest
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in:       &tfprotov5.StopProviderRequest{},
+			expected: &tfprotov6.StopProviderRequest{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.StopProviderRequest(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestStopProviderResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.StopProviderResponse
+		expected *tfprotov6.StopProviderResponse
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.StopProviderResponse{
+				Error: "test error",
+			},
+			expected: &tfprotov6.StopProviderResponse{
+				Error: "test error",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.StopProviderResponse(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestStringKind(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       tfprotov5.StringKind
+		expected tfprotov6.StringKind
+	}{
+		"markdown": {
+			in:       tfprotov5.StringKindMarkdown,
+			expected: tfprotov6.StringKindMarkdown,
+		},
+		"plain": {
+			in:       tfprotov5.StringKindPlain,
+			expected: tfprotov6.StringKindPlain,
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.StringKind(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestUpgradeResourceStateRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.UpgradeResourceStateRequest
+		expected *tfprotov6.UpgradeResourceStateRequest
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.UpgradeResourceStateRequest{
+				RawState: &tfprotov5.RawState{
+					JSON: testBytes,
+				},
+				TypeName: "test_resource",
+				Version:  1,
+			},
+			expected: &tfprotov6.UpgradeResourceStateRequest{
+				RawState: &tfprotov6.RawState{
+					JSON: testBytes,
+				},
+				TypeName: "test_resource",
+				Version:  1,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.UpgradeResourceStateRequest(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestUpgradeResourceStateResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.UpgradeResourceStateResponse
+		expected *tfprotov6.UpgradeResourceStateResponse
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.UpgradeResourceStateResponse{
+				Diagnostics:   testTfprotov5Diagnostics,
+				UpgradedState: &testTfprotov5DynamicValue,
+			},
+			expected: &tfprotov6.UpgradeResourceStateResponse{
+				Diagnostics:   testTfprotov6Diagnostics,
+				UpgradedState: &testTfprotov6DynamicValue,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.UpgradeResourceStateResponse(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestValidateDataResourceConfigRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.ValidateDataSourceConfigRequest
+		expected *tfprotov6.ValidateDataResourceConfigRequest
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.ValidateDataSourceConfigRequest{
+				Config:   &testTfprotov5DynamicValue,
+				TypeName: "test_data_source",
+			},
+			expected: &tfprotov6.ValidateDataResourceConfigRequest{
+				Config:   &testTfprotov6DynamicValue,
+				TypeName: "test_data_source",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.ValidateDataResourceConfigRequest(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestValidateDataResourceConfigResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.ValidateDataSourceConfigResponse
+		expected *tfprotov6.ValidateDataResourceConfigResponse
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.ValidateDataSourceConfigResponse{
+				Diagnostics: testTfprotov5Diagnostics,
+			},
+			expected: &tfprotov6.ValidateDataResourceConfigResponse{
+				Diagnostics: testTfprotov6Diagnostics,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.ValidateDataResourceConfigResponse(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestValidateProviderConfigRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.PrepareProviderConfigRequest
+		expected *tfprotov6.ValidateProviderConfigRequest
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.PrepareProviderConfigRequest{
+				Config: &testTfprotov5DynamicValue,
+			},
+			expected: &tfprotov6.ValidateProviderConfigRequest{
+				Config: &testTfprotov6DynamicValue,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.ValidateProviderConfigRequest(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestValidateProviderConfigResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.PrepareProviderConfigResponse
+		expected *tfprotov6.ValidateProviderConfigResponse
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.PrepareProviderConfigResponse{
+				Diagnostics:    testTfprotov5Diagnostics,
+				PreparedConfig: &testTfprotov5DynamicValue,
+			},
+			expected: &tfprotov6.ValidateProviderConfigResponse{
+				Diagnostics:    testTfprotov6Diagnostics,
+				PreparedConfig: &testTfprotov6DynamicValue,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.ValidateProviderConfigResponse(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestValidateResourceConfigRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.ValidateResourceTypeConfigRequest
+		expected *tfprotov6.ValidateResourceConfigRequest
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.ValidateResourceTypeConfigRequest{
+				Config:   &testTfprotov5DynamicValue,
+				TypeName: "test_resource",
+			},
+			expected: &tfprotov6.ValidateResourceConfigRequest{
+				Config:   &testTfprotov6DynamicValue,
+				TypeName: "test_resource",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.ValidateResourceConfigRequest(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestValidateResourceConfigResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.ValidateResourceTypeConfigResponse
+		expected *tfprotov6.ValidateResourceConfigResponse
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.ValidateResourceTypeConfigResponse{
+				Diagnostics: testTfprotov5Diagnostics,
+			},
+			expected: &tfprotov6.ValidateResourceConfigResponse{
+				Diagnostics: testTfprotov6Diagnostics,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.ValidateResourceConfigResponse(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/tfprotov6tov5/tfprotov6tov5.go
+++ b/internal/tfprotov6tov5/tfprotov6tov5.go
@@ -1,0 +1,498 @@
+package tfprotov6tov5
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+var ErrSchemaAttributeNestedTypeNotImplemented error = errors.New("SchemaAttribute NestedType is not implemented in protocol version 5")
+
+func ApplyResourceChangeRequest(in *tfprotov6.ApplyResourceChangeRequest) *tfprotov5.ApplyResourceChangeRequest {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov5.ApplyResourceChangeRequest{
+		Config:         DynamicValue(in.Config),
+		PlannedPrivate: in.PlannedPrivate,
+		PlannedState:   DynamicValue(in.PlannedState),
+		PriorState:     DynamicValue(in.PriorState),
+		ProviderMeta:   DynamicValue(in.ProviderMeta),
+		TypeName:       in.TypeName,
+	}
+}
+
+func ApplyResourceChangeResponse(in *tfprotov6.ApplyResourceChangeResponse) *tfprotov5.ApplyResourceChangeResponse {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov5.ApplyResourceChangeResponse{
+		Diagnostics:                 Diagnostics(in.Diagnostics),
+		NewState:                    DynamicValue(in.NewState),
+		Private:                     in.Private,
+		UnsafeToUseLegacyTypeSystem: in.UnsafeToUseLegacyTypeSystem, //nolint:staticcheck
+	}
+}
+
+func ConfigureProviderRequest(in *tfprotov6.ConfigureProviderRequest) *tfprotov5.ConfigureProviderRequest {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov5.ConfigureProviderRequest{
+		Config:           DynamicValue(in.Config),
+		TerraformVersion: in.TerraformVersion,
+	}
+}
+
+func ConfigureProviderResponse(in *tfprotov6.ConfigureProviderResponse) *tfprotov5.ConfigureProviderResponse {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov5.ConfigureProviderResponse{
+		Diagnostics: Diagnostics(in.Diagnostics),
+	}
+}
+
+func Diagnostics(in []*tfprotov6.Diagnostic) []*tfprotov5.Diagnostic {
+	if in == nil {
+		return nil
+	}
+
+	diags := make([]*tfprotov5.Diagnostic, 0, len(in))
+
+	for _, diag := range in {
+		if diag == nil {
+			diags = append(diags, nil)
+			continue
+		}
+
+		diags = append(diags, &tfprotov5.Diagnostic{
+			Attribute: diag.Attribute,
+			Detail:    diag.Detail,
+			Severity:  tfprotov5.DiagnosticSeverity(diag.Severity),
+			Summary:   diag.Summary,
+		})
+	}
+
+	return diags
+}
+
+func DynamicValue(in *tfprotov6.DynamicValue) *tfprotov5.DynamicValue {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov5.DynamicValue{
+		JSON:    in.JSON,
+		MsgPack: in.MsgPack,
+	}
+}
+
+func GetProviderSchemaRequest(in *tfprotov6.GetProviderSchemaRequest) *tfprotov5.GetProviderSchemaRequest {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov5.GetProviderSchemaRequest{}
+}
+
+func GetProviderSchemaResponse(in *tfprotov6.GetProviderSchemaResponse) (*tfprotov5.GetProviderSchemaResponse, error) {
+	if in == nil {
+		return nil, nil
+	}
+
+	dataSourceSchemas := make(map[string]*tfprotov5.Schema, len(in.DataSourceSchemas))
+
+	for k, v := range in.DataSourceSchemas {
+		v5Schema, err := Schema(v)
+
+		if err != nil {
+			return nil, fmt.Errorf("unable to convert data source %q schema: %w", k, err)
+		}
+
+		dataSourceSchemas[k] = v5Schema
+	}
+
+	provider, err := Schema(in.Provider)
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to convert provider schema: %w", err)
+	}
+
+	providerMeta, err := Schema(in.ProviderMeta)
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to convert provider meta schema: %w", err)
+	}
+
+	resourceSchemas := make(map[string]*tfprotov5.Schema, len(in.ResourceSchemas))
+
+	for k, v := range in.ResourceSchemas {
+		v5Schema, err := Schema(v)
+
+		if err != nil {
+			return nil, fmt.Errorf("unable to convert resource %q schema: %w", k, err)
+		}
+
+		resourceSchemas[k] = v5Schema
+	}
+
+	return &tfprotov5.GetProviderSchemaResponse{
+		DataSourceSchemas: dataSourceSchemas,
+		Diagnostics:       Diagnostics(in.Diagnostics),
+		Provider:          provider,
+		ProviderMeta:      providerMeta,
+		ResourceSchemas:   resourceSchemas,
+	}, nil
+}
+
+func ImportResourceStateRequest(in *tfprotov6.ImportResourceStateRequest) *tfprotov5.ImportResourceStateRequest {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov5.ImportResourceStateRequest{
+		ID:       in.ID,
+		TypeName: in.TypeName,
+	}
+}
+
+func ImportResourceStateResponse(in *tfprotov6.ImportResourceStateResponse) *tfprotov5.ImportResourceStateResponse {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov5.ImportResourceStateResponse{
+		Diagnostics:       Diagnostics(in.Diagnostics),
+		ImportedResources: ImportedResources(in.ImportedResources),
+	}
+}
+
+func ImportedResources(in []*tfprotov6.ImportedResource) []*tfprotov5.ImportedResource {
+	if in == nil {
+		return nil
+	}
+
+	res := make([]*tfprotov5.ImportedResource, 0, len(in))
+
+	for _, imp := range in {
+		if imp == nil {
+			res = append(res, nil)
+			continue
+		}
+
+		res = append(res, &tfprotov5.ImportedResource{
+			Private:  imp.Private,
+			State:    DynamicValue(imp.State),
+			TypeName: imp.TypeName,
+		})
+	}
+
+	return res
+}
+
+func PlanResourceChangeRequest(in *tfprotov6.PlanResourceChangeRequest) *tfprotov5.PlanResourceChangeRequest {
+	if in == nil {
+		return nil
+	}
+	return &tfprotov5.PlanResourceChangeRequest{
+		Config:           DynamicValue(in.Config),
+		PriorPrivate:     in.PriorPrivate,
+		PriorState:       DynamicValue(in.PriorState),
+		ProposedNewState: DynamicValue(in.ProposedNewState),
+		ProviderMeta:     DynamicValue(in.ProviderMeta),
+		TypeName:         in.TypeName,
+	}
+}
+
+func PlanResourceChangeResponse(in *tfprotov6.PlanResourceChangeResponse) *tfprotov5.PlanResourceChangeResponse {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov5.PlanResourceChangeResponse{
+		Diagnostics:                 Diagnostics(in.Diagnostics),
+		PlannedPrivate:              in.PlannedPrivate,
+		PlannedState:                DynamicValue(in.PlannedState),
+		RequiresReplace:             in.RequiresReplace,
+		UnsafeToUseLegacyTypeSystem: in.UnsafeToUseLegacyTypeSystem, //nolint:staticcheck
+	}
+}
+
+func PrepareProviderConfigRequest(in *tfprotov6.ValidateProviderConfigRequest) *tfprotov5.PrepareProviderConfigRequest {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov5.PrepareProviderConfigRequest{
+		Config: DynamicValue(in.Config),
+	}
+}
+
+func PrepareProviderConfigResponse(in *tfprotov6.ValidateProviderConfigResponse) *tfprotov5.PrepareProviderConfigResponse {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov5.PrepareProviderConfigResponse{
+		Diagnostics:    Diagnostics(in.Diagnostics),
+		PreparedConfig: DynamicValue(in.PreparedConfig),
+	}
+}
+
+func RawState(in *tfprotov6.RawState) *tfprotov5.RawState {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov5.RawState{
+		Flatmap: in.Flatmap,
+		JSON:    in.JSON,
+	}
+}
+
+func ReadDataSourceRequest(in *tfprotov6.ReadDataSourceRequest) *tfprotov5.ReadDataSourceRequest {
+	if in == nil {
+		return nil
+	}
+	return &tfprotov5.ReadDataSourceRequest{
+		Config:       DynamicValue(in.Config),
+		ProviderMeta: DynamicValue(in.ProviderMeta),
+		TypeName:     in.TypeName,
+	}
+}
+
+func ReadDataSourceResponse(in *tfprotov6.ReadDataSourceResponse) *tfprotov5.ReadDataSourceResponse {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov5.ReadDataSourceResponse{
+		Diagnostics: Diagnostics(in.Diagnostics),
+		State:       DynamicValue(in.State),
+	}
+}
+
+func ReadResourceRequest(in *tfprotov6.ReadResourceRequest) *tfprotov5.ReadResourceRequest {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov5.ReadResourceRequest{
+		CurrentState: DynamicValue(in.CurrentState),
+		Private:      in.Private,
+		ProviderMeta: DynamicValue(in.ProviderMeta),
+		TypeName:     in.TypeName,
+	}
+}
+
+func ReadResourceResponse(in *tfprotov6.ReadResourceResponse) *tfprotov5.ReadResourceResponse {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov5.ReadResourceResponse{
+		Diagnostics: Diagnostics(in.Diagnostics),
+		NewState:    DynamicValue(in.NewState),
+		Private:     in.Private,
+	}
+}
+
+func Schema(in *tfprotov6.Schema) (*tfprotov5.Schema, error) {
+	if in == nil {
+		return nil, nil
+	}
+
+	block, err := SchemaBlock(in.Block)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &tfprotov5.Schema{
+		Block:   block,
+		Version: in.Version,
+	}, nil
+}
+
+func SchemaAttribute(in *tfprotov6.SchemaAttribute) (*tfprotov5.SchemaAttribute, error) {
+	if in == nil {
+		return nil, nil
+	}
+
+	if in.NestedType != nil {
+		return nil, fmt.Errorf("unable to convert attribute %q schema: %w", in.Name, ErrSchemaAttributeNestedTypeNotImplemented)
+	}
+
+	return &tfprotov5.SchemaAttribute{
+		Computed:        in.Computed,
+		Deprecated:      in.Deprecated,
+		Description:     in.Description,
+		DescriptionKind: StringKind(in.DescriptionKind),
+		Name:            in.Name,
+		Optional:        in.Optional,
+		Required:        in.Required,
+		Sensitive:       in.Sensitive,
+		Type:            in.Type,
+	}, nil
+}
+
+func SchemaBlock(in *tfprotov6.SchemaBlock) (*tfprotov5.SchemaBlock, error) {
+	if in == nil {
+		return nil, nil
+	}
+
+	var attrs []*tfprotov5.SchemaAttribute
+
+	if in.Attributes != nil {
+		attrs = make([]*tfprotov5.SchemaAttribute, 0, len(in.Attributes))
+
+		for _, attr := range in.Attributes {
+			v5Attr, err := SchemaAttribute(attr)
+
+			if err != nil {
+				return nil, err
+			}
+
+			attrs = append(attrs, v5Attr)
+		}
+	}
+
+	var nestedBlocks []*tfprotov5.SchemaNestedBlock
+
+	if in.BlockTypes != nil {
+		nestedBlocks = make([]*tfprotov5.SchemaNestedBlock, 0, len(in.BlockTypes))
+
+		for _, block := range in.BlockTypes {
+			v5Block, err := SchemaNestedBlock(block)
+
+			if err != nil {
+				return nil, err
+			}
+
+			nestedBlocks = append(nestedBlocks, v5Block)
+		}
+	}
+
+	return &tfprotov5.SchemaBlock{
+		Attributes:      attrs,
+		BlockTypes:      nestedBlocks,
+		Deprecated:      in.Deprecated,
+		Description:     in.Description,
+		DescriptionKind: StringKind(in.DescriptionKind),
+		Version:         in.Version,
+	}, nil
+}
+
+func SchemaNestedBlock(in *tfprotov6.SchemaNestedBlock) (*tfprotov5.SchemaNestedBlock, error) {
+	if in == nil {
+		return nil, nil
+	}
+
+	block, err := SchemaBlock(in.Block)
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to convert block %q schema: %w", in.TypeName, err)
+	}
+
+	return &tfprotov5.SchemaNestedBlock{
+		Block:    block,
+		MaxItems: in.MaxItems,
+		MinItems: in.MinItems,
+		Nesting:  tfprotov5.SchemaNestedBlockNestingMode(in.Nesting),
+		TypeName: in.TypeName,
+	}, nil
+}
+
+func StopProviderRequest(in *tfprotov6.StopProviderRequest) *tfprotov5.StopProviderRequest {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov5.StopProviderRequest{}
+}
+
+func StopProviderResponse(in *tfprotov6.StopProviderResponse) *tfprotov5.StopProviderResponse {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov5.StopProviderResponse{
+		Error: in.Error,
+	}
+}
+
+func StringKind(in tfprotov6.StringKind) tfprotov5.StringKind {
+	return tfprotov5.StringKind(in)
+}
+
+func UpgradeResourceStateRequest(in *tfprotov6.UpgradeResourceStateRequest) *tfprotov5.UpgradeResourceStateRequest {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov5.UpgradeResourceStateRequest{
+		RawState: RawState(in.RawState),
+		TypeName: in.TypeName,
+		Version:  in.Version,
+	}
+}
+
+func UpgradeResourceStateResponse(in *tfprotov6.UpgradeResourceStateResponse) *tfprotov5.UpgradeResourceStateResponse {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov5.UpgradeResourceStateResponse{
+		Diagnostics:   Diagnostics(in.Diagnostics),
+		UpgradedState: DynamicValue(in.UpgradedState),
+	}
+}
+
+func ValidateDataSourceConfigRequest(in *tfprotov6.ValidateDataResourceConfigRequest) *tfprotov5.ValidateDataSourceConfigRequest {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov5.ValidateDataSourceConfigRequest{
+		Config:   DynamicValue(in.Config),
+		TypeName: in.TypeName,
+	}
+}
+
+func ValidateDataSourceConfigResponse(in *tfprotov6.ValidateDataResourceConfigResponse) *tfprotov5.ValidateDataSourceConfigResponse {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov5.ValidateDataSourceConfigResponse{
+		Diagnostics: Diagnostics(in.Diagnostics),
+	}
+}
+
+func ValidateResourceTypeConfigRequest(in *tfprotov6.ValidateResourceConfigRequest) *tfprotov5.ValidateResourceTypeConfigRequest {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov5.ValidateResourceTypeConfigRequest{
+		Config:   DynamicValue(in.Config),
+		TypeName: in.TypeName,
+	}
+}
+
+func ValidateResourceTypeConfigResponse(in *tfprotov6.ValidateResourceConfigResponse) *tfprotov5.ValidateResourceTypeConfigResponse {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov5.ValidateResourceTypeConfigResponse{
+		Diagnostics: Diagnostics(in.Diagnostics),
+	}
+}

--- a/internal/tfprotov6tov5/tfprotov6tov5_test.go
+++ b/internal/tfprotov6tov5/tfprotov6tov5_test.go
@@ -1,0 +1,1739 @@
+package tfprotov6tov5_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-plugin-mux/internal/tfprotov6tov5"
+)
+
+var (
+	testBytes []byte = []byte("test")
+
+	testTfprotov5Diagnostics []*tfprotov5.Diagnostic = []*tfprotov5.Diagnostic{
+		{
+			Detail:   "test detail",
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "test summary",
+		},
+	}
+	testTfprotov6Diagnostics []*tfprotov6.Diagnostic = []*tfprotov6.Diagnostic{
+		{
+			Detail:   "test detail",
+			Severity: tfprotov6.DiagnosticSeverityError,
+			Summary:  "test summary",
+		},
+	}
+
+	testTfprotov5DynamicValue tfprotov5.DynamicValue
+	testTfprotov6DynamicValue tfprotov6.DynamicValue
+
+	testTfprotov5Schema *tfprotov5.Schema = &tfprotov5.Schema{
+		Block: &tfprotov5.SchemaBlock{
+			Attributes: []*tfprotov5.SchemaAttribute{
+				{
+					Name:     "test",
+					Required: true,
+				},
+			},
+			Version: 1,
+		},
+		Version: 1,
+	}
+	testTfprotov6Schema *tfprotov6.Schema = &tfprotov6.Schema{
+		Block: &tfprotov6.SchemaBlock{
+			Attributes: []*tfprotov6.SchemaAttribute{
+				{
+					Name:     "test",
+					Required: true,
+				},
+			},
+			Version: 1,
+		},
+		Version: 1,
+	}
+)
+
+func init() {
+	testTfprotov5DynamicValue, _ = tfprotov5.NewDynamicValue(tftypes.String, tftypes.NewValue(tftypes.String, "test"))
+	testTfprotov6DynamicValue, _ = tfprotov6.NewDynamicValue(tftypes.String, tftypes.NewValue(tftypes.String, "test"))
+}
+
+func TestApplyResourceChangeRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov6.ApplyResourceChangeRequest
+		expected *tfprotov5.ApplyResourceChangeRequest
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.ApplyResourceChangeRequest{
+				Config:         &testTfprotov6DynamicValue,
+				PlannedPrivate: testBytes,
+				PlannedState:   &testTfprotov6DynamicValue,
+				PriorState:     &testTfprotov6DynamicValue,
+				ProviderMeta:   &testTfprotov6DynamicValue,
+				TypeName:       "test",
+			},
+			expected: &tfprotov5.ApplyResourceChangeRequest{
+				Config:         &testTfprotov5DynamicValue,
+				PlannedPrivate: testBytes,
+				PlannedState:   &testTfprotov5DynamicValue,
+				PriorState:     &testTfprotov5DynamicValue,
+				ProviderMeta:   &testTfprotov5DynamicValue,
+				TypeName:       "test",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.ApplyResourceChangeRequest(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestApplyResourceChangeResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov6.ApplyResourceChangeResponse
+		expected *tfprotov5.ApplyResourceChangeResponse
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.ApplyResourceChangeResponse{
+				Diagnostics:                 testTfprotov6Diagnostics,
+				NewState:                    &testTfprotov6DynamicValue,
+				Private:                     testBytes,
+				UnsafeToUseLegacyTypeSystem: true,
+			},
+			expected: &tfprotov5.ApplyResourceChangeResponse{
+				Diagnostics:                 testTfprotov5Diagnostics,
+				NewState:                    &testTfprotov5DynamicValue,
+				Private:                     testBytes,
+				UnsafeToUseLegacyTypeSystem: true,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.ApplyResourceChangeResponse(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestConfigureProviderRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov6.ConfigureProviderRequest
+		expected *tfprotov5.ConfigureProviderRequest
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.ConfigureProviderRequest{
+				Config:           &testTfprotov6DynamicValue,
+				TerraformVersion: "1.2.3",
+			},
+			expected: &tfprotov5.ConfigureProviderRequest{
+				Config:           &testTfprotov5DynamicValue,
+				TerraformVersion: "1.2.3",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.ConfigureProviderRequest(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestConfigureProviderResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov6.ConfigureProviderResponse
+		expected *tfprotov5.ConfigureProviderResponse
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.ConfigureProviderResponse{
+				Diagnostics: testTfprotov6Diagnostics,
+			},
+			expected: &tfprotov5.ConfigureProviderResponse{
+				Diagnostics: testTfprotov5Diagnostics,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.ConfigureProviderResponse(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       []*tfprotov6.Diagnostic
+		expected []*tfprotov5.Diagnostic
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"empty": {
+			in:       []*tfprotov6.Diagnostic{},
+			expected: []*tfprotov5.Diagnostic{},
+		},
+		"one": {
+			in:       testTfprotov6Diagnostics,
+			expected: testTfprotov5Diagnostics,
+		},
+		"multiple": {
+			in: []*tfprotov6.Diagnostic{
+				{
+					Detail:   "test detail 1",
+					Severity: tfprotov6.DiagnosticSeverityError,
+					Summary:  "test summary 2",
+				},
+				{
+					Detail:   "test detail 1",
+					Severity: tfprotov6.DiagnosticSeverityError,
+					Summary:  "test summary 2",
+				},
+			},
+			expected: []*tfprotov5.Diagnostic{
+				{
+					Detail:   "test detail 1",
+					Severity: tfprotov5.DiagnosticSeverityError,
+					Summary:  "test summary 2",
+				},
+				{
+					Detail:   "test detail 1",
+					Severity: tfprotov5.DiagnosticSeverityError,
+					Summary:  "test summary 2",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.Diagnostics(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestDynamicValue(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov6.DynamicValue
+		expected *tfprotov5.DynamicValue
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.DynamicValue{
+				JSON:    testBytes,
+				MsgPack: testBytes,
+			},
+			expected: &tfprotov5.DynamicValue{
+				JSON:    testBytes,
+				MsgPack: testBytes,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.DynamicValue(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestGetProviderSchemaRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov6.GetProviderSchemaRequest
+		expected *tfprotov5.GetProviderSchemaRequest
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in:       &tfprotov6.GetProviderSchemaRequest{},
+			expected: &tfprotov5.GetProviderSchemaRequest{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.GetProviderSchemaRequest(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestGetProviderSchemaResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in            *tfprotov6.GetProviderSchemaResponse
+		expected      *tfprotov5.GetProviderSchemaResponse
+		expectedError error
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": testTfprotov6Schema,
+				},
+				Diagnostics:  testTfprotov6Diagnostics,
+				Provider:     testTfprotov6Schema,
+				ProviderMeta: testTfprotov6Schema,
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": testTfprotov6Schema,
+				},
+			},
+			expected: &tfprotov5.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov5.Schema{
+					"test_data_source": testTfprotov5Schema,
+				},
+				Diagnostics:  testTfprotov5Diagnostics,
+				Provider:     testTfprotov5Schema,
+				ProviderMeta: testTfprotov5Schema,
+				ResourceSchemas: map[string]*tfprotov5.Schema{
+					"test_resource": testTfprotov5Schema,
+				},
+			},
+		},
+		"data-source-nested-attribute-error": {
+			in: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name: "test_attribute",
+									NestedType: &tfprotov6.SchemaObject{
+										Attributes: []*tfprotov6.SchemaAttribute{
+											{
+												Name:     "test_nested_attribute",
+												Required: true,
+											},
+										},
+									},
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected:      nil,
+			expectedError: fmt.Errorf("unable to convert data source \"test_data_source\" schema: unable to convert attribute \"test_attribute\" schema: %w", tfprotov6tov5.ErrSchemaAttributeNestedTypeNotImplemented),
+		},
+		"provider-nested-attribute-error": {
+			in: &tfprotov6.GetProviderSchemaResponse{
+				Provider: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name: "test_attribute",
+								NestedType: &tfprotov6.SchemaObject{
+									Attributes: []*tfprotov6.SchemaAttribute{
+										{
+											Name:     "test_nested_attribute",
+											Required: true,
+										},
+									},
+								},
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+			expected:      nil,
+			expectedError: fmt.Errorf("unable to convert provider schema: unable to convert attribute \"test_attribute\" schema: %w", tfprotov6tov5.ErrSchemaAttributeNestedTypeNotImplemented),
+		},
+		"provider-meta-nested-attribute-error": {
+			in: &tfprotov6.GetProviderSchemaResponse{
+				ProviderMeta: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name: "test_attribute",
+								NestedType: &tfprotov6.SchemaObject{
+									Attributes: []*tfprotov6.SchemaAttribute{
+										{
+											Name:     "test_nested_attribute",
+											Required: true,
+										},
+									},
+								},
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+			expected:      nil,
+			expectedError: fmt.Errorf("unable to convert provider meta schema: unable to convert attribute \"test_attribute\" schema: %w", tfprotov6tov5.ErrSchemaAttributeNestedTypeNotImplemented),
+		},
+		"resource-nested-attribute-error": {
+			in: &tfprotov6.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name: "test_attribute",
+									NestedType: &tfprotov6.SchemaObject{
+										Attributes: []*tfprotov6.SchemaAttribute{
+											{
+												Name:     "test_nested_attribute",
+												Required: true,
+											},
+										},
+									},
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected:      nil,
+			expectedError: fmt.Errorf("unable to convert resource \"test_resource\" schema: unable to convert attribute \"test_attribute\" schema: %w", tfprotov6tov5.ErrSchemaAttributeNestedTypeNotImplemented),
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := tfprotov6tov5.GetProviderSchemaResponse(testCase.in)
+
+			if err != nil {
+				if testCase.expectedError == nil {
+					t.Fatalf("wanted no error, got unexpected error: %s", err)
+				}
+
+				if !strings.Contains(err.Error(), testCase.expectedError.Error()) {
+					t.Fatalf("expected error %q, got: %s", testCase.expectedError, err)
+				}
+			} else if testCase.expectedError != nil {
+				t.Fatalf("got no error, expected error: %s", testCase.expectedError)
+			}
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestImportResourceStateRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov6.ImportResourceStateRequest
+		expected *tfprotov5.ImportResourceStateRequest
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.ImportResourceStateRequest{
+				ID:       "test-id",
+				TypeName: "test_resource",
+			},
+			expected: &tfprotov5.ImportResourceStateRequest{
+				ID:       "test-id",
+				TypeName: "test_resource",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.ImportResourceStateRequest(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestImportResourceStateResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov6.ImportResourceStateResponse
+		expected *tfprotov5.ImportResourceStateResponse
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.ImportResourceStateResponse{
+				Diagnostics: testTfprotov6Diagnostics,
+				ImportedResources: []*tfprotov6.ImportedResource{
+					{
+						Private:  testBytes,
+						State:    &testTfprotov6DynamicValue,
+						TypeName: "test_resource1",
+					},
+				},
+			},
+			expected: &tfprotov5.ImportResourceStateResponse{
+				Diagnostics: testTfprotov5Diagnostics,
+				ImportedResources: []*tfprotov5.ImportedResource{
+					{
+						Private:  testBytes,
+						State:    &testTfprotov5DynamicValue,
+						TypeName: "test_resource1",
+					},
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.ImportResourceStateResponse(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestImportedResources(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       []*tfprotov6.ImportedResource
+		expected []*tfprotov5.ImportedResource
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"empty": {
+			in:       []*tfprotov6.ImportedResource{},
+			expected: []*tfprotov5.ImportedResource{},
+		},
+		"one": {
+			in: []*tfprotov6.ImportedResource{
+				{
+					Private:  testBytes,
+					State:    &testTfprotov6DynamicValue,
+					TypeName: "test_resource1",
+				},
+			},
+			expected: []*tfprotov5.ImportedResource{
+				{
+					Private:  testBytes,
+					State:    &testTfprotov5DynamicValue,
+					TypeName: "test_resource1",
+				},
+			},
+		},
+
+		"multiple": {
+			in: []*tfprotov6.ImportedResource{
+				{
+					Private:  testBytes,
+					State:    &testTfprotov6DynamicValue,
+					TypeName: "test_resource1",
+				},
+				{
+					Private:  testBytes,
+					State:    &testTfprotov6DynamicValue,
+					TypeName: "test_resource2",
+				},
+			},
+			expected: []*tfprotov5.ImportedResource{
+				{
+					Private:  testBytes,
+					State:    &testTfprotov5DynamicValue,
+					TypeName: "test_resource1",
+				},
+				{
+					Private:  testBytes,
+					State:    &testTfprotov5DynamicValue,
+					TypeName: "test_resource2",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.ImportedResources(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestPlanResourceChangeRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov6.PlanResourceChangeRequest
+		expected *tfprotov5.PlanResourceChangeRequest
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.PlanResourceChangeRequest{
+				Config:           &testTfprotov6DynamicValue,
+				PriorPrivate:     testBytes,
+				PriorState:       &testTfprotov6DynamicValue,
+				ProposedNewState: &testTfprotov6DynamicValue,
+				ProviderMeta:     &testTfprotov6DynamicValue,
+				TypeName:         "test_resource",
+			},
+			expected: &tfprotov5.PlanResourceChangeRequest{
+				Config:           &testTfprotov5DynamicValue,
+				PriorPrivate:     testBytes,
+				PriorState:       &testTfprotov5DynamicValue,
+				ProposedNewState: &testTfprotov5DynamicValue,
+				ProviderMeta:     &testTfprotov5DynamicValue,
+				TypeName:         "test_resource",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.PlanResourceChangeRequest(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestPlanResourceChangeResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov6.PlanResourceChangeResponse
+		expected *tfprotov5.PlanResourceChangeResponse
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.PlanResourceChangeResponse{
+				Diagnostics:    testTfprotov6Diagnostics,
+				PlannedPrivate: testBytes,
+				PlannedState:   &testTfprotov6DynamicValue,
+				RequiresReplace: []*tftypes.AttributePath{
+					tftypes.NewAttributePath().WithAttributeName("test"),
+				},
+				UnsafeToUseLegacyTypeSystem: true,
+			},
+			expected: &tfprotov5.PlanResourceChangeResponse{
+				Diagnostics:    testTfprotov5Diagnostics,
+				PlannedPrivate: testBytes,
+				PlannedState:   &testTfprotov5DynamicValue,
+				RequiresReplace: []*tftypes.AttributePath{
+					tftypes.NewAttributePath().WithAttributeName("test"),
+				},
+				UnsafeToUseLegacyTypeSystem: true,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.PlanResourceChangeResponse(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestPrepareProviderConfigRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov6.ValidateProviderConfigRequest
+		expected *tfprotov5.PrepareProviderConfigRequest
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.ValidateProviderConfigRequest{
+				Config: &testTfprotov6DynamicValue,
+			},
+			expected: &tfprotov5.PrepareProviderConfigRequest{
+				Config: &testTfprotov5DynamicValue,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.PrepareProviderConfigRequest(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestPrepareProviderConfigResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov6.ValidateProviderConfigResponse
+		expected *tfprotov5.PrepareProviderConfigResponse
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.ValidateProviderConfigResponse{
+				Diagnostics:    testTfprotov6Diagnostics,
+				PreparedConfig: &testTfprotov6DynamicValue,
+			},
+			expected: &tfprotov5.PrepareProviderConfigResponse{
+				Diagnostics:    testTfprotov5Diagnostics,
+				PreparedConfig: &testTfprotov5DynamicValue,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.PrepareProviderConfigResponse(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestRawState(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov6.RawState
+		expected *tfprotov5.RawState
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.RawState{
+				Flatmap: map[string]string{"testkey": "testvalue"},
+				JSON:    testBytes,
+			},
+			expected: &tfprotov5.RawState{
+				Flatmap: map[string]string{"testkey": "testvalue"},
+				JSON:    testBytes,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.RawState(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestReadDataSourceRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov6.ReadDataSourceRequest
+		expected *tfprotov5.ReadDataSourceRequest
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.ReadDataSourceRequest{
+				Config:       &testTfprotov6DynamicValue,
+				ProviderMeta: &testTfprotov6DynamicValue,
+				TypeName:     "test_data_source",
+			},
+			expected: &tfprotov5.ReadDataSourceRequest{
+				Config:       &testTfprotov5DynamicValue,
+				ProviderMeta: &testTfprotov5DynamicValue,
+				TypeName:     "test_data_source",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.ReadDataSourceRequest(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestReadDataSourceResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov6.ReadDataSourceResponse
+		expected *tfprotov5.ReadDataSourceResponse
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.ReadDataSourceResponse{
+				Diagnostics: testTfprotov6Diagnostics,
+				State:       &testTfprotov6DynamicValue,
+			},
+			expected: &tfprotov5.ReadDataSourceResponse{
+				Diagnostics: testTfprotov5Diagnostics,
+				State:       &testTfprotov5DynamicValue,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.ReadDataSourceResponse(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestReadResourceRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov6.ReadResourceRequest
+		expected *tfprotov5.ReadResourceRequest
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.ReadResourceRequest{
+				CurrentState: &testTfprotov6DynamicValue,
+				Private:      testBytes,
+				ProviderMeta: &testTfprotov6DynamicValue,
+				TypeName:     "test_resource",
+			},
+			expected: &tfprotov5.ReadResourceRequest{
+				CurrentState: &testTfprotov5DynamicValue,
+				Private:      testBytes,
+				ProviderMeta: &testTfprotov5DynamicValue,
+				TypeName:     "test_resource",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.ReadResourceRequest(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestReadResourceResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov6.ReadResourceResponse
+		expected *tfprotov5.ReadResourceResponse
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.ReadResourceResponse{
+				Diagnostics: testTfprotov6Diagnostics,
+				NewState:    &testTfprotov6DynamicValue,
+				Private:     testBytes,
+			},
+			expected: &tfprotov5.ReadResourceResponse{
+				Diagnostics: testTfprotov5Diagnostics,
+				NewState:    &testTfprotov5DynamicValue,
+				Private:     testBytes,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.ReadResourceResponse(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSchema(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in            *tfprotov6.Schema
+		expected      *tfprotov5.Schema
+		expectedError error
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in:       testTfprotov6Schema,
+			expected: testTfprotov5Schema,
+		},
+		"nested-attribute-error": {
+			in: &tfprotov6.Schema{
+				Block: &tfprotov6.SchemaBlock{
+					Attributes: []*tfprotov6.SchemaAttribute{
+						{
+							Name: "test_attribute",
+							NestedType: &tfprotov6.SchemaObject{
+								Attributes: []*tfprotov6.SchemaAttribute{
+									{
+										Name:     "test_nested_attribute",
+										Required: true,
+									},
+								},
+							},
+							Required: true,
+						},
+					},
+				},
+			},
+			expected:      nil,
+			expectedError: fmt.Errorf("unable to convert attribute \"test_attribute\" schema: %w", tfprotov6tov5.ErrSchemaAttributeNestedTypeNotImplemented),
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := tfprotov6tov5.Schema(testCase.in)
+
+			if err != nil {
+				if testCase.expectedError == nil {
+					t.Fatalf("wanted no error, got unexpected error: %s", err)
+				}
+
+				if !strings.Contains(err.Error(), testCase.expectedError.Error()) {
+					t.Fatalf("expected error %q, got: %s", testCase.expectedError, err)
+				}
+			} else if testCase.expectedError != nil {
+				t.Fatalf("got no error, expected error: %s", testCase.expectedError)
+			}
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSchemaAttribute(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in            *tfprotov6.SchemaAttribute
+		expected      *tfprotov5.SchemaAttribute
+		expectedError error
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.SchemaAttribute{
+				Computed:        true,
+				Deprecated:      true,
+				Description:     "test description",
+				DescriptionKind: tfprotov6.StringKindPlain,
+				Name:            "test",
+				Optional:        true,
+				Required:        true,
+				Sensitive:       true,
+				Type:            tftypes.String,
+			},
+			expected: &tfprotov5.SchemaAttribute{
+				Computed:        true,
+				Deprecated:      true,
+				Description:     "test description",
+				DescriptionKind: tfprotov5.StringKindPlain,
+				Name:            "test",
+				Optional:        true,
+				Required:        true,
+				Sensitive:       true,
+				Type:            tftypes.String,
+			},
+		},
+		"NestedType-error": {
+			in: &tfprotov6.SchemaAttribute{
+				Name: "test",
+				NestedType: &tfprotov6.SchemaObject{
+					Attributes: []*tfprotov6.SchemaAttribute{
+						{
+							Name:     "test_nested_attribute",
+							Required: true,
+						},
+					},
+				},
+				Required: true,
+			},
+			expected:      nil,
+			expectedError: fmt.Errorf("unable to convert attribute \"test\" schema: %w", tfprotov6tov5.ErrSchemaAttributeNestedTypeNotImplemented),
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := tfprotov6tov5.SchemaAttribute(testCase.in)
+
+			if err != nil {
+				if testCase.expectedError == nil {
+					t.Fatalf("wanted no error, got unexpected error: %s", err)
+				}
+
+				if !strings.Contains(err.Error(), testCase.expectedError.Error()) {
+					t.Fatalf("expected error %q, got: %s", testCase.expectedError, err)
+				}
+			} else if testCase.expectedError != nil {
+				t.Fatalf("got no error, expected error: %s", testCase.expectedError)
+			}
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSchemaBlock(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in            *tfprotov6.SchemaBlock
+		expected      *tfprotov5.SchemaBlock
+		expectedError error
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.SchemaBlock{
+				Attributes: []*tfprotov6.SchemaAttribute{
+					{
+						Name:     "test_attribute",
+						Required: true,
+					},
+				},
+				BlockTypes: []*tfprotov6.SchemaNestedBlock{
+					{
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+								},
+							},
+						},
+						TypeName: "test_block",
+					},
+				},
+				Deprecated:      true,
+				Description:     "test description",
+				DescriptionKind: tfprotov6.StringKindPlain,
+				Version:         1,
+			},
+			expected: &tfprotov5.SchemaBlock{
+				Attributes: []*tfprotov5.SchemaAttribute{
+					{
+						Name:     "test_attribute",
+						Required: true,
+					},
+				},
+				BlockTypes: []*tfprotov5.SchemaNestedBlock{
+					{
+						Block: &tfprotov5.SchemaBlock{
+							Attributes: []*tfprotov5.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+								},
+							},
+						},
+						TypeName: "test_block",
+					},
+				},
+				Deprecated:      true,
+				Description:     "test description",
+				DescriptionKind: tfprotov5.StringKindPlain,
+				Version:         1,
+			},
+		},
+		"nested-attribute-error": {
+			in: &tfprotov6.SchemaBlock{
+				Attributes: []*tfprotov6.SchemaAttribute{
+					{
+						Name: "test_attribute",
+						NestedType: &tfprotov6.SchemaObject{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_nested_attribute",
+									Required: true,
+								},
+							},
+						},
+						Required: true,
+					},
+				},
+			},
+			expected:      nil,
+			expectedError: fmt.Errorf("unable to convert attribute \"test_attribute\" schema: %w", tfprotov6tov5.ErrSchemaAttributeNestedTypeNotImplemented),
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := tfprotov6tov5.SchemaBlock(testCase.in)
+
+			if err != nil {
+				if testCase.expectedError == nil {
+					t.Fatalf("wanted no error, got unexpected error: %s", err)
+				}
+
+				if !strings.Contains(err.Error(), testCase.expectedError.Error()) {
+					t.Fatalf("expected error %q, got: %s", testCase.expectedError, err)
+				}
+			} else if testCase.expectedError != nil {
+				t.Fatalf("got no error, expected error: %s", testCase.expectedError)
+			}
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSchemaNestedBlock(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in            *tfprotov6.SchemaNestedBlock
+		expected      *tfprotov5.SchemaNestedBlock
+		expectedError error
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.SchemaNestedBlock{
+				Block: &tfprotov6.SchemaBlock{
+					Attributes: []*tfprotov6.SchemaAttribute{
+						{
+							Name:     "test_attribute",
+							Required: true,
+						},
+					},
+				},
+				MaxItems: 1,
+				MinItems: 1,
+				Nesting:  tfprotov6.SchemaNestedBlockNestingModeList,
+				TypeName: "test_block",
+			},
+			expected: &tfprotov5.SchemaNestedBlock{
+				Block: &tfprotov5.SchemaBlock{
+					Attributes: []*tfprotov5.SchemaAttribute{
+						{
+							Name:     "test_attribute",
+							Required: true,
+						},
+					},
+				},
+				MaxItems: 1,
+				MinItems: 1,
+				Nesting:  tfprotov5.SchemaNestedBlockNestingModeList,
+				TypeName: "test_block",
+			},
+		},
+		"nested-attribute-error": {
+			in: &tfprotov6.SchemaNestedBlock{
+				Block: &tfprotov6.SchemaBlock{
+					Attributes: []*tfprotov6.SchemaAttribute{
+						{
+							Name: "test_attribute",
+							NestedType: &tfprotov6.SchemaObject{
+								Attributes: []*tfprotov6.SchemaAttribute{
+									{
+										Name:     "test_nested_attribute",
+										Required: true,
+									},
+								},
+							},
+							Required: true,
+						},
+					},
+				},
+				Nesting:  tfprotov6.SchemaNestedBlockNestingModeList,
+				TypeName: "test_block",
+			},
+			expected:      nil,
+			expectedError: fmt.Errorf("unable to convert block \"test_block\" schema: unable to convert attribute \"test_attribute\" schema: %w", tfprotov6tov5.ErrSchemaAttributeNestedTypeNotImplemented),
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := tfprotov6tov5.SchemaNestedBlock(testCase.in)
+
+			if err != nil {
+				if testCase.expectedError == nil {
+					t.Fatalf("wanted no error, got unexpected error: %s", err)
+				}
+
+				if !strings.Contains(err.Error(), testCase.expectedError.Error()) {
+					t.Fatalf("expected error %q, got: %s", testCase.expectedError, err)
+				}
+			} else if testCase.expectedError != nil {
+				t.Fatalf("got no error, expected error: %s", testCase.expectedError)
+			}
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestStopProviderRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov6.StopProviderRequest
+		expected *tfprotov5.StopProviderRequest
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in:       &tfprotov6.StopProviderRequest{},
+			expected: &tfprotov5.StopProviderRequest{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.StopProviderRequest(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestStopProviderResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov6.StopProviderResponse
+		expected *tfprotov5.StopProviderResponse
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.StopProviderResponse{
+				Error: "test error",
+			},
+			expected: &tfprotov5.StopProviderResponse{
+				Error: "test error",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.StopProviderResponse(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestStringKind(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       tfprotov6.StringKind
+		expected tfprotov5.StringKind
+	}{
+		"markdown": {
+			in:       tfprotov6.StringKindMarkdown,
+			expected: tfprotov5.StringKindMarkdown,
+		},
+		"plain": {
+			in:       tfprotov6.StringKindPlain,
+			expected: tfprotov5.StringKindPlain,
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.StringKind(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestUpgradeResourceStateRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov6.UpgradeResourceStateRequest
+		expected *tfprotov5.UpgradeResourceStateRequest
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.UpgradeResourceStateRequest{
+				RawState: &tfprotov6.RawState{
+					JSON: testBytes,
+				},
+				TypeName: "test_resource",
+				Version:  1,
+			},
+			expected: &tfprotov5.UpgradeResourceStateRequest{
+				RawState: &tfprotov5.RawState{
+					JSON: testBytes,
+				},
+				TypeName: "test_resource",
+				Version:  1,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.UpgradeResourceStateRequest(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestUpgradeResourceStateResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov6.UpgradeResourceStateResponse
+		expected *tfprotov5.UpgradeResourceStateResponse
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.UpgradeResourceStateResponse{
+				Diagnostics:   testTfprotov6Diagnostics,
+				UpgradedState: &testTfprotov6DynamicValue,
+			},
+			expected: &tfprotov5.UpgradeResourceStateResponse{
+				Diagnostics:   testTfprotov5Diagnostics,
+				UpgradedState: &testTfprotov5DynamicValue,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.UpgradeResourceStateResponse(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestValidateDataSourceConfigRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov6.ValidateDataResourceConfigRequest
+		expected *tfprotov5.ValidateDataSourceConfigRequest
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.ValidateDataResourceConfigRequest{
+				Config:   &testTfprotov6DynamicValue,
+				TypeName: "test_data_source",
+			},
+			expected: &tfprotov5.ValidateDataSourceConfigRequest{
+				Config:   &testTfprotov5DynamicValue,
+				TypeName: "test_data_source",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.ValidateDataSourceConfigRequest(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestValidateDataSourceConfigResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov6.ValidateDataResourceConfigResponse
+		expected *tfprotov5.ValidateDataSourceConfigResponse
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.ValidateDataResourceConfigResponse{
+				Diagnostics: testTfprotov6Diagnostics,
+			},
+			expected: &tfprotov5.ValidateDataSourceConfigResponse{
+				Diagnostics: testTfprotov5Diagnostics,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.ValidateDataSourceConfigResponse(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestValidateResourceTypeConfigRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov6.ValidateResourceConfigRequest
+		expected *tfprotov5.ValidateResourceTypeConfigRequest
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.ValidateResourceConfigRequest{
+				Config:   &testTfprotov6DynamicValue,
+				TypeName: "test_resource",
+			},
+			expected: &tfprotov5.ValidateResourceTypeConfigRequest{
+				Config:   &testTfprotov5DynamicValue,
+				TypeName: "test_resource",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.ValidateResourceTypeConfigRequest(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestValidateResourceTypeConfigResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov6.ValidateResourceConfigResponse
+		expected *tfprotov5.ValidateResourceTypeConfigResponse
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.ValidateResourceConfigResponse{
+				Diagnostics: testTfprotov6Diagnostics,
+			},
+			expected: &tfprotov5.ValidateResourceTypeConfigResponse{
+				Diagnostics: testTfprotov5Diagnostics,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.ValidateResourceTypeConfigResponse(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/tf5to6server/tf5to6server.go
+++ b/tf5to6server/tf5to6server.go
@@ -1,0 +1,167 @@
+package tf5to6server
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-mux/internal/tfprotov5tov6"
+	"github.com/hashicorp/terraform-plugin-mux/internal/tfprotov6tov5"
+)
+
+// UpgradeServer wraps a protocol version 5 ProviderServer in a protocol
+// version 6 server. Protocol version 6 is fully forwards compatible with
+// protocol version 5, so no additional validation is performed.
+//
+// Protocol version 6 servers require Terraform CLI 1.0 or later.
+//
+// Terraform CLI 1.1.5 or later is required for terraform-provider-sdk based
+// protocol version 5 servers to properly upgrade to protocol version 6.
+func UpgradeServer(_ context.Context, v5server func() tfprotov5.ProviderServer) (tfprotov6.ProviderServer, error) {
+	return v5tov6Server{
+		v5Server: v5server(),
+	}, nil
+}
+
+var _ tfprotov6.ProviderServer = v5tov6Server{}
+
+type v5tov6Server struct {
+	v5Server tfprotov5.ProviderServer
+}
+
+func (s v5tov6Server) ApplyResourceChange(ctx context.Context, req *tfprotov6.ApplyResourceChangeRequest) (*tfprotov6.ApplyResourceChangeResponse, error) {
+	v5Req := tfprotov6tov5.ApplyResourceChangeRequest(req)
+	v5Resp, err := s.v5Server.ApplyResourceChange(ctx, v5Req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfprotov5tov6.ApplyResourceChangeResponse(v5Resp), nil
+}
+
+func (s v5tov6Server) ConfigureProvider(ctx context.Context, req *tfprotov6.ConfigureProviderRequest) (*tfprotov6.ConfigureProviderResponse, error) {
+	v5Req := tfprotov6tov5.ConfigureProviderRequest(req)
+	v5Resp, err := s.v5Server.ConfigureProvider(ctx, v5Req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfprotov5tov6.ConfigureProviderResponse(v5Resp), nil
+}
+
+func (s v5tov6Server) GetProviderSchema(ctx context.Context, req *tfprotov6.GetProviderSchemaRequest) (*tfprotov6.GetProviderSchemaResponse, error) {
+	v5Req := tfprotov6tov5.GetProviderSchemaRequest(req)
+	v5Resp, err := s.v5Server.GetProviderSchema(ctx, v5Req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfprotov5tov6.GetProviderSchemaResponse(v5Resp), nil
+}
+
+func (s v5tov6Server) ImportResourceState(ctx context.Context, req *tfprotov6.ImportResourceStateRequest) (*tfprotov6.ImportResourceStateResponse, error) {
+	v5Req := tfprotov6tov5.ImportResourceStateRequest(req)
+	v5Resp, err := s.v5Server.ImportResourceState(ctx, v5Req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfprotov5tov6.ImportResourceStateResponse(v5Resp), nil
+}
+
+func (s v5tov6Server) PlanResourceChange(ctx context.Context, req *tfprotov6.PlanResourceChangeRequest) (*tfprotov6.PlanResourceChangeResponse, error) {
+	v5Req := tfprotov6tov5.PlanResourceChangeRequest(req)
+	v5Resp, err := s.v5Server.PlanResourceChange(ctx, v5Req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfprotov5tov6.PlanResourceChangeResponse(v5Resp), nil
+}
+
+// ProviderServer is a function compatible with tf6server.Serve.
+func (s v5tov6Server) ProviderServer() tfprotov6.ProviderServer {
+	return s
+}
+
+func (s v5tov6Server) ReadDataSource(ctx context.Context, req *tfprotov6.ReadDataSourceRequest) (*tfprotov6.ReadDataSourceResponse, error) {
+	v5Req := tfprotov6tov5.ReadDataSourceRequest(req)
+	v5Resp, err := s.v5Server.ReadDataSource(ctx, v5Req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfprotov5tov6.ReadDataSourceResponse(v5Resp), nil
+}
+
+func (s v5tov6Server) ReadResource(ctx context.Context, req *tfprotov6.ReadResourceRequest) (*tfprotov6.ReadResourceResponse, error) {
+	v5Req := tfprotov6tov5.ReadResourceRequest(req)
+	v5Resp, err := s.v5Server.ReadResource(ctx, v5Req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfprotov5tov6.ReadResourceResponse(v5Resp), nil
+}
+
+func (s v5tov6Server) StopProvider(ctx context.Context, req *tfprotov6.StopProviderRequest) (*tfprotov6.StopProviderResponse, error) {
+	v5Req := tfprotov6tov5.StopProviderRequest(req)
+	v5Resp, err := s.v5Server.StopProvider(ctx, v5Req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfprotov5tov6.StopProviderResponse(v5Resp), nil
+}
+
+func (s v5tov6Server) UpgradeResourceState(ctx context.Context, req *tfprotov6.UpgradeResourceStateRequest) (*tfprotov6.UpgradeResourceStateResponse, error) {
+	v5Req := tfprotov6tov5.UpgradeResourceStateRequest(req)
+	v5Resp, err := s.v5Server.UpgradeResourceState(ctx, v5Req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfprotov5tov6.UpgradeResourceStateResponse(v5Resp), nil
+}
+
+func (s v5tov6Server) ValidateDataResourceConfig(ctx context.Context, req *tfprotov6.ValidateDataResourceConfigRequest) (*tfprotov6.ValidateDataResourceConfigResponse, error) {
+	v5Req := tfprotov6tov5.ValidateDataSourceConfigRequest(req)
+	v5Resp, err := s.v5Server.ValidateDataSourceConfig(ctx, v5Req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfprotov5tov6.ValidateDataResourceConfigResponse(v5Resp), nil
+}
+
+func (s v5tov6Server) ValidateProviderConfig(ctx context.Context, req *tfprotov6.ValidateProviderConfigRequest) (*tfprotov6.ValidateProviderConfigResponse, error) {
+	v5Req := tfprotov6tov5.PrepareProviderConfigRequest(req)
+	v5Resp, err := s.v5Server.PrepareProviderConfig(ctx, v5Req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfprotov5tov6.ValidateProviderConfigResponse(v5Resp), nil
+}
+
+func (s v5tov6Server) ValidateResourceConfig(ctx context.Context, req *tfprotov6.ValidateResourceConfigRequest) (*tfprotov6.ValidateResourceConfigResponse, error) {
+	v5Req := tfprotov6tov5.ValidateResourceTypeConfigRequest(req)
+	v5Resp, err := s.v5Server.ValidateResourceTypeConfig(ctx, v5Req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfprotov5tov6.ValidateResourceConfigResponse(v5Resp), nil
+}

--- a/tf5to6server/tf5to6server_test.go
+++ b/tf5to6server/tf5to6server_test.go
@@ -1,0 +1,461 @@
+package tf5to6server_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-plugin-mux/internal/tf5testserver"
+	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
+)
+
+func TestUpgradeServer(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		v5Server      func() tfprotov5.ProviderServer
+		expectedError error
+	}{
+		"compatible": {
+			v5Server: (&tf5testserver.TestServer{
+				DataSourceSchemas: map[string]*tfprotov5.Schema{
+					"test_data_source": {},
+				},
+				ProviderSchema: &tfprotov5.Schema{
+					Block: &tfprotov5.SchemaBlock{
+						Attributes: []*tfprotov5.SchemaAttribute{
+							{
+								Name:            "test_attribute",
+								Type:            tftypes.String,
+								Required:        true,
+								Description:     "test_attribute description",
+								DescriptionKind: tfprotov5.StringKindPlain,
+							},
+						},
+						BlockTypes: []*tfprotov5.SchemaNestedBlock{
+							{
+								TypeName: "test_block",
+								Nesting:  tfprotov5.SchemaNestedBlockNestingModeList,
+								Block: &tfprotov5.SchemaBlock{
+									Description:     "test_block description",
+									DescriptionKind: tfprotov5.StringKindPlain,
+									Attributes: []*tfprotov5.SchemaAttribute{
+										{
+											Name:            "test_block_attribute",
+											Type:            tftypes.Number,
+											Required:        true,
+											Description:     "test_block_attribute description",
+											DescriptionKind: tfprotov5.StringKindPlain,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ProviderMetaSchema: &tfprotov5.Schema{
+					Block: &tfprotov5.SchemaBlock{
+						Attributes: []*tfprotov5.SchemaAttribute{
+							{
+								Name:            "test_attribute",
+								Type:            tftypes.String,
+								Required:        true,
+								Description:     "test_attribute description",
+								DescriptionKind: tfprotov5.StringKindPlain,
+							},
+						},
+						BlockTypes: []*tfprotov5.SchemaNestedBlock{
+							{
+								TypeName: "test_block",
+								Nesting:  tfprotov5.SchemaNestedBlockNestingModeList,
+								Block: &tfprotov5.SchemaBlock{
+									Description:     "test_block description",
+									DescriptionKind: tfprotov5.StringKindPlain,
+									Attributes: []*tfprotov5.SchemaAttribute{
+										{
+											Name:            "test_block_attribute",
+											Type:            tftypes.Number,
+											Required:        true,
+											Description:     "test_block_attribute description",
+											DescriptionKind: tfprotov5.StringKindPlain,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov5.Schema{
+					"test_resource": {},
+				},
+			}).ProviderServer,
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := tf5to6server.UpgradeServer(context.Background(), testCase.v5Server)
+
+			if err != nil {
+				if testCase.expectedError == nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+
+				if !strings.Contains(err.Error(), testCase.expectedError.Error()) {
+					t.Fatalf("expected error %q, got: %s", testCase.expectedError, err)
+				}
+			}
+
+			if err == nil && testCase.expectedError != nil {
+				t.Fatalf("expected error: %s", testCase.expectedError)
+			}
+		})
+	}
+}
+
+func TestV6ToV5ServerApplyResourceChange(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v5server := &tf5testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov5.Schema{
+			"test_resource": {},
+		},
+	}
+
+	v6server, err := tf5to6server.UpgradeServer(context.Background(), v5server.ProviderServer)
+
+	if err != nil {
+		t.Fatalf("unexpected error downgrading server: %s", err)
+	}
+
+	_, err = v6server.ApplyResourceChange(ctx, &tfprotov6.ApplyResourceChangeRequest{
+		TypeName: "test_resource",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !v5server.ApplyResourceChangeCalled["test_resource"] {
+		t.Errorf("expected test_resource ApplyResourceChange to be called")
+	}
+}
+
+func TestV6ToV5ServerConfigureProvider(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v5server := &tf5testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov5.Schema{
+			"test_resource": {},
+		},
+	}
+
+	v6server, err := tf5to6server.UpgradeServer(context.Background(), v5server.ProviderServer)
+
+	if err != nil {
+		t.Fatalf("unexpected error downgrading server: %s", err)
+	}
+
+	_, err = v6server.ConfigureProvider(ctx, &tfprotov6.ConfigureProviderRequest{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !v5server.ConfigureProviderCalled {
+		t.Errorf("expected ConfigureProvider to be called")
+	}
+}
+
+func TestV6ToV5ServerGetProviderSchema(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v5server := &tf5testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov5.Schema{
+			"test_resource": {},
+		},
+	}
+
+	v6server, err := tf5to6server.UpgradeServer(context.Background(), v5server.ProviderServer)
+
+	if err != nil {
+		t.Fatalf("unexpected error downgrading server: %s", err)
+	}
+
+	_, err = v6server.GetProviderSchema(ctx, &tfprotov6.GetProviderSchemaRequest{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !v5server.GetProviderSchemaCalled {
+		t.Errorf("expected GetProviderSchema to be called")
+	}
+}
+
+func TestV6ToV5ServerImportResourceState(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v5server := &tf5testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov5.Schema{
+			"test_resource": {},
+		},
+	}
+
+	v6server, err := tf5to6server.UpgradeServer(context.Background(), v5server.ProviderServer)
+
+	if err != nil {
+		t.Fatalf("unexpected error downgrading server: %s", err)
+	}
+
+	_, err = v6server.ImportResourceState(ctx, &tfprotov6.ImportResourceStateRequest{
+		TypeName: "test_resource",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !v5server.ImportResourceStateCalled["test_resource"] {
+		t.Errorf("expected test_resource ImportResourceState to be called")
+	}
+}
+
+func TestV6ToV5ServerPlanResourceChange(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v5server := &tf5testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov5.Schema{
+			"test_resource": {},
+		},
+	}
+
+	v6server, err := tf5to6server.UpgradeServer(context.Background(), v5server.ProviderServer)
+
+	if err != nil {
+		t.Fatalf("unexpected error downgrading server: %s", err)
+	}
+
+	_, err = v6server.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{
+		TypeName: "test_resource",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !v5server.PlanResourceChangeCalled["test_resource"] {
+		t.Errorf("expected test_resource PlanResourceChange to be called")
+	}
+}
+
+func TestV6ToV5ServerReadDataSource(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v5server := &tf5testserver.TestServer{
+		DataSourceSchemas: map[string]*tfprotov5.Schema{
+			"test_data_source": {},
+		},
+	}
+
+	v6server, err := tf5to6server.UpgradeServer(context.Background(), v5server.ProviderServer)
+
+	if err != nil {
+		t.Fatalf("unexpected error downgrading server: %s", err)
+	}
+
+	_, err = v6server.ReadDataSource(ctx, &tfprotov6.ReadDataSourceRequest{
+		TypeName: "test_data_source",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !v5server.ReadDataSourceCalled["test_data_source"] {
+		t.Errorf("expected test_data_source ReadDataSource to be called")
+	}
+}
+
+func TestV6ToV5ServerReadResource(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v5server := &tf5testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov5.Schema{
+			"test_resource": {},
+		},
+	}
+
+	v6server, err := tf5to6server.UpgradeServer(context.Background(), v5server.ProviderServer)
+
+	if err != nil {
+		t.Fatalf("unexpected error downgrading server: %s", err)
+	}
+
+	_, err = v6server.ReadResource(ctx, &tfprotov6.ReadResourceRequest{
+		TypeName: "test_resource",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !v5server.ReadResourceCalled["test_resource"] {
+		t.Errorf("expected test_resource ReadResource to be called")
+	}
+}
+
+func TestV6ToV5ServerStopProvider(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v5server := &tf5testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov5.Schema{
+			"test_resource": {},
+		},
+	}
+
+	v6server, err := tf5to6server.UpgradeServer(context.Background(), v5server.ProviderServer)
+
+	if err != nil {
+		t.Fatalf("unexpected error downgrading server: %s", err)
+	}
+
+	_, err = v6server.StopProvider(ctx, &tfprotov6.StopProviderRequest{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !v5server.StopProviderCalled {
+		t.Errorf("expected StopProvider to be called")
+	}
+}
+
+func TestV6ToV5ServerUpgradeResourceState(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v5server := &tf5testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov5.Schema{
+			"test_resource": {},
+		},
+	}
+
+	v6server, err := tf5to6server.UpgradeServer(context.Background(), v5server.ProviderServer)
+
+	if err != nil {
+		t.Fatalf("unexpected error downgrading server: %s", err)
+	}
+
+	_, err = v6server.UpgradeResourceState(ctx, &tfprotov6.UpgradeResourceStateRequest{
+		TypeName: "test_resource",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !v5server.UpgradeResourceStateCalled["test_resource"] {
+		t.Errorf("expected test_resource UpgradeResourceState to be called")
+	}
+}
+
+func TestV6ToV5ServerValidateDataResourceConfig(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v5server := &tf5testserver.TestServer{
+		DataSourceSchemas: map[string]*tfprotov5.Schema{
+			"test_data_source": {},
+		},
+	}
+
+	v6server, err := tf5to6server.UpgradeServer(context.Background(), v5server.ProviderServer)
+
+	if err != nil {
+		t.Fatalf("unexpected error downgrading server: %s", err)
+	}
+
+	_, err = v6server.ValidateDataResourceConfig(ctx, &tfprotov6.ValidateDataResourceConfigRequest{
+		TypeName: "test_data_source",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !v5server.ValidateDataSourceConfigCalled["test_data_source"] {
+		t.Errorf("expected test_data_source ValidateDataSourceConfig to be called")
+	}
+}
+
+func TestV6ToV5ServerValidateProviderConfig(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v5server := &tf5testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov5.Schema{
+			"test_resource": {},
+		},
+	}
+
+	v6server, err := tf5to6server.UpgradeServer(context.Background(), v5server.ProviderServer)
+
+	if err != nil {
+		t.Fatalf("unexpected error downgrading server: %s", err)
+	}
+
+	_, err = v6server.ValidateProviderConfig(ctx, &tfprotov6.ValidateProviderConfigRequest{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !v5server.PrepareProviderConfigCalled {
+		t.Errorf("expected PrepareProviderConfig to be called")
+	}
+}
+
+func TestV6ToV5ServerValidateResourceConfig(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v5server := &tf5testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov5.Schema{
+			"test_resource": {},
+		},
+	}
+
+	v6server, err := tf5to6server.UpgradeServer(context.Background(), v5server.ProviderServer)
+
+	if err != nil {
+		t.Fatalf("unexpected error downgrading server: %s", err)
+	}
+
+	_, err = v6server.ValidateResourceConfig(ctx, &tfprotov6.ValidateResourceConfigRequest{
+		TypeName: "test_resource",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !v5server.ValidateResourceTypeConfigCalled["test_resource"] {
+		t.Errorf("expected test_resource ValidateResourceConfig to be called")
+	}
+}

--- a/tf6to5server/tf6to5server.go
+++ b/tf6to5server/tf6to5server.go
@@ -1,0 +1,179 @@
+package tf6to5server
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-mux/internal/tfprotov5tov6"
+	"github.com/hashicorp/terraform-plugin-mux/internal/tfprotov6tov5"
+)
+
+// DowngradeServer wraps a protocol version 6 ProviderServer in a protocol
+// version 5 server. Protocol version 5 is not backwards compatible with
+// protocol version 6, so additional validation is performed:
+//
+// - GetProviderSchema is called to ensure SchemaAttribute.NestedType
+//   (nested attributes) are not implemented.
+//
+// Protocol version 5 servers require Terraform CLI 0.12 or later.
+func DowngradeServer(ctx context.Context, v6server func() tfprotov6.ProviderServer) (tfprotov5.ProviderServer, error) {
+	v6Resp, err := v6server().GetProviderSchema(ctx, &tfprotov6.GetProviderSchemaRequest{})
+
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = tfprotov6tov5.GetProviderSchemaResponse(v6Resp)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return v6tov5Server{
+		v6Server: v6server(),
+	}, nil
+}
+
+var _ tfprotov5.ProviderServer = v6tov5Server{}
+
+type v6tov5Server struct {
+	v6Server tfprotov6.ProviderServer
+}
+
+func (s v6tov5Server) ApplyResourceChange(ctx context.Context, req *tfprotov5.ApplyResourceChangeRequest) (*tfprotov5.ApplyResourceChangeResponse, error) {
+	v6Req := tfprotov5tov6.ApplyResourceChangeRequest(req)
+	v6Resp, err := s.v6Server.ApplyResourceChange(ctx, v6Req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfprotov6tov5.ApplyResourceChangeResponse(v6Resp), nil
+}
+
+func (s v6tov5Server) ConfigureProvider(ctx context.Context, req *tfprotov5.ConfigureProviderRequest) (*tfprotov5.ConfigureProviderResponse, error) {
+	v6Req := tfprotov5tov6.ConfigureProviderRequest(req)
+	v6Resp, err := s.v6Server.ConfigureProvider(ctx, v6Req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfprotov6tov5.ConfigureProviderResponse(v6Resp), nil
+}
+
+func (s v6tov5Server) GetProviderSchema(ctx context.Context, req *tfprotov5.GetProviderSchemaRequest) (*tfprotov5.GetProviderSchemaResponse, error) {
+	v6Req := tfprotov5tov6.GetProviderSchemaRequest(req)
+	v6Resp, err := s.v6Server.GetProviderSchema(ctx, v6Req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfprotov6tov5.GetProviderSchemaResponse(v6Resp)
+}
+
+func (s v6tov5Server) ImportResourceState(ctx context.Context, req *tfprotov5.ImportResourceStateRequest) (*tfprotov5.ImportResourceStateResponse, error) {
+	v6Req := tfprotov5tov6.ImportResourceStateRequest(req)
+	v6Resp, err := s.v6Server.ImportResourceState(ctx, v6Req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfprotov6tov5.ImportResourceStateResponse(v6Resp), nil
+}
+
+func (s v6tov5Server) PlanResourceChange(ctx context.Context, req *tfprotov5.PlanResourceChangeRequest) (*tfprotov5.PlanResourceChangeResponse, error) {
+	v6Req := tfprotov5tov6.PlanResourceChangeRequest(req)
+	v6Resp, err := s.v6Server.PlanResourceChange(ctx, v6Req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfprotov6tov5.PlanResourceChangeResponse(v6Resp), nil
+}
+
+func (s v6tov5Server) PrepareProviderConfig(ctx context.Context, req *tfprotov5.PrepareProviderConfigRequest) (*tfprotov5.PrepareProviderConfigResponse, error) {
+	v6Req := tfprotov5tov6.ValidateProviderConfigRequest(req)
+	v6Resp, err := s.v6Server.ValidateProviderConfig(ctx, v6Req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfprotov6tov5.PrepareProviderConfigResponse(v6Resp), nil
+}
+
+// ProviderServer is a function compatible with tf5server.Serve.
+func (s v6tov5Server) ProviderServer() tfprotov5.ProviderServer {
+	return s
+}
+
+func (s v6tov5Server) ReadDataSource(ctx context.Context, req *tfprotov5.ReadDataSourceRequest) (*tfprotov5.ReadDataSourceResponse, error) {
+	v6Req := tfprotov5tov6.ReadDataSourceRequest(req)
+	v6Resp, err := s.v6Server.ReadDataSource(ctx, v6Req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfprotov6tov5.ReadDataSourceResponse(v6Resp), nil
+}
+
+func (s v6tov5Server) ReadResource(ctx context.Context, req *tfprotov5.ReadResourceRequest) (*tfprotov5.ReadResourceResponse, error) {
+	v6Req := tfprotov5tov6.ReadResourceRequest(req)
+	v6Resp, err := s.v6Server.ReadResource(ctx, v6Req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfprotov6tov5.ReadResourceResponse(v6Resp), nil
+}
+
+func (s v6tov5Server) StopProvider(ctx context.Context, req *tfprotov5.StopProviderRequest) (*tfprotov5.StopProviderResponse, error) {
+	v6Req := tfprotov5tov6.StopProviderRequest(req)
+	v6Resp, err := s.v6Server.StopProvider(ctx, v6Req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfprotov6tov5.StopProviderResponse(v6Resp), nil
+}
+
+func (s v6tov5Server) UpgradeResourceState(ctx context.Context, req *tfprotov5.UpgradeResourceStateRequest) (*tfprotov5.UpgradeResourceStateResponse, error) {
+	v6Req := tfprotov5tov6.UpgradeResourceStateRequest(req)
+	v6Resp, err := s.v6Server.UpgradeResourceState(ctx, v6Req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfprotov6tov5.UpgradeResourceStateResponse(v6Resp), nil
+}
+
+func (s v6tov5Server) ValidateDataSourceConfig(ctx context.Context, req *tfprotov5.ValidateDataSourceConfigRequest) (*tfprotov5.ValidateDataSourceConfigResponse, error) {
+	v6Req := tfprotov5tov6.ValidateDataResourceConfigRequest(req)
+	v6Resp, err := s.v6Server.ValidateDataResourceConfig(ctx, v6Req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfprotov6tov5.ValidateDataSourceConfigResponse(v6Resp), nil
+}
+
+func (s v6tov5Server) ValidateResourceTypeConfig(ctx context.Context, req *tfprotov5.ValidateResourceTypeConfigRequest) (*tfprotov5.ValidateResourceTypeConfigResponse, error) {
+	v6Req := tfprotov5tov6.ValidateResourceConfigRequest(req)
+	v6Resp, err := s.v6Server.ValidateResourceConfig(ctx, v6Req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfprotov6tov5.ValidateResourceTypeConfigResponse(v6Resp), nil
+}

--- a/tf6to5server/tf6to5server_test.go
+++ b/tf6to5server/tf6to5server_test.go
@@ -1,0 +1,551 @@
+package tf6to5server_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-plugin-mux/internal/tf6testserver"
+	"github.com/hashicorp/terraform-plugin-mux/internal/tfprotov6tov5"
+	"github.com/hashicorp/terraform-plugin-mux/tf6to5server"
+)
+
+func TestDowngradeServer(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		v6Server      func() tfprotov6.ProviderServer
+		expectedError error
+	}{
+		"compatible": {
+			v6Server: (&tf6testserver.TestServer{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {},
+				},
+				ProviderSchema: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:            "test_attribute",
+								Type:            tftypes.String,
+								Required:        true,
+								Description:     "test_attribute description",
+								DescriptionKind: tfprotov6.StringKindPlain,
+							},
+						},
+						BlockTypes: []*tfprotov6.SchemaNestedBlock{
+							{
+								TypeName: "test_block",
+								Nesting:  tfprotov6.SchemaNestedBlockNestingModeList,
+								Block: &tfprotov6.SchemaBlock{
+									Description:     "test_block description",
+									DescriptionKind: tfprotov6.StringKindPlain,
+									Attributes: []*tfprotov6.SchemaAttribute{
+										{
+											Name:            "test_block_attribute",
+											Type:            tftypes.Number,
+											Required:        true,
+											Description:     "test_block_attribute description",
+											DescriptionKind: tfprotov6.StringKindPlain,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ProviderMetaSchema: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:            "test_attribute",
+								Type:            tftypes.String,
+								Required:        true,
+								Description:     "test_attribute description",
+								DescriptionKind: tfprotov6.StringKindPlain,
+							},
+						},
+						BlockTypes: []*tfprotov6.SchemaNestedBlock{
+							{
+								TypeName: "test_block",
+								Nesting:  tfprotov6.SchemaNestedBlockNestingModeList,
+								Block: &tfprotov6.SchemaBlock{
+									Description:     "test_block description",
+									DescriptionKind: tfprotov6.StringKindPlain,
+									Attributes: []*tfprotov6.SchemaAttribute{
+										{
+											Name:            "test_block_attribute",
+											Type:            tftypes.Number,
+											Required:        true,
+											Description:     "test_block_attribute description",
+											DescriptionKind: tfprotov6.StringKindPlain,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {},
+				},
+			}).ProviderServer,
+		},
+		"SchemaAttribute-NestedType-data-source": {
+			v6Server: (&tf6testserver.TestServer{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name: "test_attribute",
+									NestedType: &tfprotov6.SchemaObject{
+										Attributes: []*tfprotov6.SchemaAttribute{},
+										Nesting:    tfprotov6.SchemaObjectNestingModeSingle,
+									},
+									Required:        true,
+									Description:     "test_attribute description",
+									DescriptionKind: tfprotov6.StringKindPlain,
+								},
+							},
+						},
+					},
+				},
+			}).ProviderServer,
+			expectedError: fmt.Errorf("unable to convert data source \"test_data_source\" schema: unable to convert attribute \"test_attribute\" schema: %s", tfprotov6tov5.ErrSchemaAttributeNestedTypeNotImplemented),
+		},
+		"SchemaAttribute-NestedType-provider": {
+			v6Server: (&tf6testserver.TestServer{
+				ProviderSchema: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name: "test_attribute",
+								NestedType: &tfprotov6.SchemaObject{
+									Attributes: []*tfprotov6.SchemaAttribute{},
+									Nesting:    tfprotov6.SchemaObjectNestingModeSingle,
+								},
+								Required:        true,
+								Description:     "test_attribute description",
+								DescriptionKind: tfprotov6.StringKindPlain,
+							},
+						},
+					},
+				},
+			}).ProviderServer,
+			expectedError: fmt.Errorf("unable to convert provider schema: unable to convert attribute \"test_attribute\" schema: %s", tfprotov6tov5.ErrSchemaAttributeNestedTypeNotImplemented),
+		},
+		"SchemaAttribute-NestedType-provider-meta": {
+			v6Server: (&tf6testserver.TestServer{
+				ProviderMetaSchema: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name: "test_attribute",
+								NestedType: &tfprotov6.SchemaObject{
+									Attributes: []*tfprotov6.SchemaAttribute{},
+									Nesting:    tfprotov6.SchemaObjectNestingModeSingle,
+								},
+								Required:        true,
+								Description:     "test_attribute description",
+								DescriptionKind: tfprotov6.StringKindPlain,
+							},
+						},
+					},
+				},
+			}).ProviderServer,
+			expectedError: fmt.Errorf("unable to convert provider meta schema: unable to convert attribute \"test_attribute\" schema: %s", tfprotov6tov5.ErrSchemaAttributeNestedTypeNotImplemented),
+		},
+		"SchemaAttribute-NestedType-resource": {
+			v6Server: (&tf6testserver.TestServer{
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name: "test_attribute",
+									NestedType: &tfprotov6.SchemaObject{
+										Attributes: []*tfprotov6.SchemaAttribute{},
+										Nesting:    tfprotov6.SchemaObjectNestingModeSingle,
+									},
+									Required:        true,
+									Description:     "test_attribute description",
+									DescriptionKind: tfprotov6.StringKindPlain,
+								},
+							},
+						},
+					},
+				},
+			}).ProviderServer,
+			expectedError: fmt.Errorf("unable to convert resource \"test_resource\" schema: unable to convert attribute \"test_attribute\" schema: %s", tfprotov6tov5.ErrSchemaAttributeNestedTypeNotImplemented),
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := tf6to5server.DowngradeServer(context.Background(), testCase.v6Server)
+
+			if err != nil {
+				if testCase.expectedError == nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+
+				if !strings.Contains(err.Error(), testCase.expectedError.Error()) {
+					t.Fatalf("expected error %q, got: %s", testCase.expectedError, err)
+				}
+			}
+
+			if err == nil && testCase.expectedError != nil {
+				t.Fatalf("expected error: %s", testCase.expectedError)
+			}
+		})
+	}
+}
+
+func TestV6ToV5ServerApplyResourceChange(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v6server := &tf6testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov6.Schema{
+			"test_resource": {},
+		},
+	}
+
+	v5server, err := tf6to5server.DowngradeServer(context.Background(), v6server.ProviderServer)
+
+	if err != nil {
+		t.Fatalf("unexpected error downgrading server: %s", err)
+	}
+
+	_, err = v5server.ApplyResourceChange(ctx, &tfprotov5.ApplyResourceChangeRequest{
+		TypeName: "test_resource",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !v6server.ApplyResourceChangeCalled["test_resource"] {
+		t.Errorf("expected test_resource ApplyResourceChange to be called")
+	}
+}
+
+func TestV6ToV5ServerConfigureProvider(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v6server := &tf6testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov6.Schema{
+			"test_resource": {},
+		},
+	}
+
+	v5server, err := tf6to5server.DowngradeServer(context.Background(), v6server.ProviderServer)
+
+	if err != nil {
+		t.Fatalf("unexpected error downgrading server: %s", err)
+	}
+
+	_, err = v5server.ConfigureProvider(ctx, &tfprotov5.ConfigureProviderRequest{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !v6server.ConfigureProviderCalled {
+		t.Errorf("expected ConfigureProvider to be called")
+	}
+}
+
+func TestV6ToV5ServerGetProviderSchema(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v6server := &tf6testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov6.Schema{
+			"test_resource": {},
+		},
+	}
+
+	v5server, err := tf6to5server.DowngradeServer(context.Background(), v6server.ProviderServer)
+
+	if err != nil {
+		t.Fatalf("unexpected error downgrading server: %s", err)
+	}
+
+	_, err = v5server.GetProviderSchema(ctx, &tfprotov5.GetProviderSchemaRequest{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !v6server.GetProviderSchemaCalled {
+		t.Errorf("expected GetProviderSchema to be called")
+	}
+}
+
+func TestV6ToV5ServerImportResourceState(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v6server := &tf6testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov6.Schema{
+			"test_resource": {},
+		},
+	}
+
+	v5server, err := tf6to5server.DowngradeServer(context.Background(), v6server.ProviderServer)
+
+	if err != nil {
+		t.Fatalf("unexpected error downgrading server: %s", err)
+	}
+
+	_, err = v5server.ImportResourceState(ctx, &tfprotov5.ImportResourceStateRequest{
+		TypeName: "test_resource",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !v6server.ImportResourceStateCalled["test_resource"] {
+		t.Errorf("expected test_resource ImportResourceState to be called")
+	}
+}
+
+func TestV6ToV5ServerPlanResourceChange(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v6server := &tf6testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov6.Schema{
+			"test_resource": {},
+		},
+	}
+
+	v5server, err := tf6to5server.DowngradeServer(context.Background(), v6server.ProviderServer)
+
+	if err != nil {
+		t.Fatalf("unexpected error downgrading server: %s", err)
+	}
+
+	_, err = v5server.PlanResourceChange(ctx, &tfprotov5.PlanResourceChangeRequest{
+		TypeName: "test_resource",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !v6server.PlanResourceChangeCalled["test_resource"] {
+		t.Errorf("expected test_resource PlanResourceChange to be called")
+	}
+}
+
+func TestV6ToV5ServerPrepareProviderConfig(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v6server := &tf6testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov6.Schema{
+			"test_resource": {},
+		},
+	}
+
+	v5server, err := tf6to5server.DowngradeServer(context.Background(), v6server.ProviderServer)
+
+	if err != nil {
+		t.Fatalf("unexpected error downgrading server: %s", err)
+	}
+
+	_, err = v5server.PrepareProviderConfig(ctx, &tfprotov5.PrepareProviderConfigRequest{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !v6server.ValidateProviderConfigCalled {
+		t.Errorf("expected ValidateProviderConfig to be called")
+	}
+}
+
+func TestV6ToV5ServerReadDataSource(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v6server := &tf6testserver.TestServer{
+		DataSourceSchemas: map[string]*tfprotov6.Schema{
+			"test_data_source": {},
+		},
+	}
+
+	v5server, err := tf6to5server.DowngradeServer(context.Background(), v6server.ProviderServer)
+
+	if err != nil {
+		t.Fatalf("unexpected error downgrading server: %s", err)
+	}
+
+	_, err = v5server.ReadDataSource(ctx, &tfprotov5.ReadDataSourceRequest{
+		TypeName: "test_data_source",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !v6server.ReadDataSourceCalled["test_data_source"] {
+		t.Errorf("expected test_data_source ReadDataSource to be called")
+	}
+}
+
+func TestV6ToV5ServerReadResource(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v6server := &tf6testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov6.Schema{
+			"test_resource": {},
+		},
+	}
+
+	v5server, err := tf6to5server.DowngradeServer(context.Background(), v6server.ProviderServer)
+
+	if err != nil {
+		t.Fatalf("unexpected error downgrading server: %s", err)
+	}
+
+	_, err = v5server.ReadResource(ctx, &tfprotov5.ReadResourceRequest{
+		TypeName: "test_resource",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !v6server.ReadResourceCalled["test_resource"] {
+		t.Errorf("expected test_resource ReadResource to be called")
+	}
+}
+
+func TestV6ToV5ServerStopProvider(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v6server := &tf6testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov6.Schema{
+			"test_resource": {},
+		},
+	}
+
+	v5server, err := tf6to5server.DowngradeServer(context.Background(), v6server.ProviderServer)
+
+	if err != nil {
+		t.Fatalf("unexpected error downgrading server: %s", err)
+	}
+
+	_, err = v5server.StopProvider(ctx, &tfprotov5.StopProviderRequest{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !v6server.StopProviderCalled {
+		t.Errorf("expected StopProvider to be called")
+	}
+}
+
+func TestV6ToV5ServerUpgradeResourceState(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v6server := &tf6testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov6.Schema{
+			"test_resource": {},
+		},
+	}
+
+	v5server, err := tf6to5server.DowngradeServer(context.Background(), v6server.ProviderServer)
+
+	if err != nil {
+		t.Fatalf("unexpected error downgrading server: %s", err)
+	}
+
+	_, err = v5server.UpgradeResourceState(ctx, &tfprotov5.UpgradeResourceStateRequest{
+		TypeName: "test_resource",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !v6server.UpgradeResourceStateCalled["test_resource"] {
+		t.Errorf("expected test_resource UpgradeResourceState to be called")
+	}
+}
+
+func TestV6ToV5ServerValidateDataSourceConfig(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v6server := &tf6testserver.TestServer{
+		DataSourceSchemas: map[string]*tfprotov6.Schema{
+			"test_data_source": {},
+		},
+	}
+
+	v5server, err := tf6to5server.DowngradeServer(context.Background(), v6server.ProviderServer)
+
+	if err != nil {
+		t.Fatalf("unexpected error downgrading server: %s", err)
+	}
+
+	_, err = v5server.ValidateDataSourceConfig(ctx, &tfprotov5.ValidateDataSourceConfigRequest{
+		TypeName: "test_data_source",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !v6server.ValidateDataResourceConfigCalled["test_data_source"] {
+		t.Errorf("expected test_data_source ValidateDataResourceConfig to be called")
+	}
+}
+
+func TestV6ToV5ServerValidateResourceTypeConfig(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v6server := &tf6testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov6.Schema{
+			"test_resource": {},
+		},
+	}
+
+	v5server, err := tf6to5server.DowngradeServer(context.Background(), v6server.ProviderServer)
+
+	if err != nil {
+		t.Fatalf("unexpected error downgrading server: %s", err)
+	}
+
+	_, err = v5server.ValidateResourceTypeConfig(ctx, &tfprotov5.ValidateResourceTypeConfigRequest{
+		TypeName: "test_resource",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !v6server.ValidateResourceConfigCalled["test_resource"] {
+		t.Errorf("expected test_resource ValidateResourceConfig to be called")
+	}
+}


### PR DESCRIPTION
Closes #33

These packages handle upgrading and downgrading protocol servers. This enables additional provider combinations, such as terraform-plugin-sdk/v2 and terraform-plugin-framework.