### PR TITLE
Fixing the formatting of the generated godoc for the 4 key packages of this library

### DIFF
--- a/tf5muxserver/doc.go
+++ b/tf5muxserver/doc.go
@@ -1,12 +1,12 @@
-// Combine multiple protocol version 5 provider servers into a single server.
+// Package tf5muxserver combines multiple provider servers that implement protocol version 5, into a single server.
 //
 // Supported protocol version 5 provider servers include any which implement
-// the github.com/hashicorp/terraform-plugin-go/tfprotov5.ProviderServer
+// the tfprotov5.ProviderServer (https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov5#ProviderServer)
 // interface, such as:
 //
-// - github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server
-// - github.com/hashicorp/terraform-plugin-mux/tf6to5server
-// - github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema
+//     - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server
+//     - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf6to5server
+//     - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema
 //
 // Refer to the NewMuxServer() function for creating a combined server.
 package tf5muxserver

--- a/tf5to6server/doc.go
+++ b/tf5to6server/doc.go
@@ -1,12 +1,12 @@
-// Translate a protocol version 5 provider server into protocol version 6.
+// Package tf5to6server translates a provider that implements protocol version 5, into one that implements protocol version 6.
 //
 // Supported protocol version 5 provider servers include any which implement
-// the github.com/hashicorp/terraform-plugin-go/tfprotov5.ProviderServer
+// the tfprotov5.ProviderServer (https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov5#ProviderServer)
 // interface, such as:
 //
-// - github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server
-// - github.com/hashicorp/terraform-plugin-mux/tf5muxserver
-// - github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema
+//     - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server
+//     - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf5muxserver
+//     - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema
 //
 // Refer to the UpgradeServer() function for wrapping a server.
 package tf5to6server

--- a/tf6muxserver/doc.go
+++ b/tf6muxserver/doc.go
@@ -1,12 +1,12 @@
-// Combine multiple protocol version 6 provider servers into a single server.
+// Package tf6muxserver combines multiple provider servers that implement protocol version 6, into a single server.
 //
 // Supported protocol version 6 provider servers include any which implement
-// the github.com/hashicorp/terraform-plugin-go/tfprotov6.ProviderServer
+// the tfprotov6.ProviderServer (https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov6#ProviderServer)
 // interface, such as:
 //
-// - github.com/hashicorp/terraform-plugin-framework
-// - github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server
-// - github.com/hashicorp/terraform-plugin-mux/tf5to6server
+//     - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework
+//     - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server
+//     - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf5to6server
 //
 // Refer to the NewMuxServer() function for creating a combined server.
 package tf6muxserver

--- a/tf6to5server/doc.go
+++ b/tf6to5server/doc.go
@@ -1,12 +1,12 @@
-// Translate a protocol version 6 provider server into protocol version 5.
+// Package tf6to5server translates a provider that implements protocol version 6, into one that implements protocol version 5.
 //
 // Supported protocol version 6 provider servers include any which implement
-// the github.com/hashicorp/terraform-plugin-go/tfprotov6.ProviderServer
+// the tfprotov6.ProviderServer (https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov6#ProviderServer)
 // interface, such as:
 //
-// - github.com/hashicorp/terraform-plugin-framework
-// - github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server
-// - github.com/hashicorp/terraform-plugin-mux/tf6muxserver
+//     - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework
+//     - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server
+//     - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf6muxserver
 //
 // Refer to the DowngradeServer() function for wrapping a server.
 package tf6to5server


### PR DESCRIPTION
* Minor godoc formatting fix
* Added links that point to the actual pkg.go.dev pages of the referenced types/structs
* To appease my IDE, I have also changed slightly the first line to start with `Package X...`: I suspect that with the right linter, this would have been picked up