### PR TITLE
all: Run Go 1.19 fmt

### DIFF
--- a/tf5muxserver/doc.go
+++ b/tf5muxserver/doc.go
@@ -4,9 +4,9 @@
 // the tfprotov5.ProviderServer (https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov5#ProviderServer)
 // interface, such as:
 //
-//     - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server
-//     - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf6to5server
-//     - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema
+//   - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server
+//   - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf6to5server
+//   - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema
 //
 // Refer to the NewMuxServer() function for creating a combined server.
 package tf5muxserver

--- a/tf5muxserver/mux_server.go
+++ b/tf5muxserver/mux_server.go
@@ -39,10 +39,10 @@ func (s muxServer) ProviderServer() tfprotov5.ProviderServer {
 // tfprotov5.ProviderServers specified. The GetProviderSchema method of each
 // is called to verify that the overall muxed server is compatible by ensuring:
 //
-//  - All provider schemas exactly match
-//  - All provider meta schemas exactly match
-//  - Only one provider implements each managed resource
-//  - Only one provider implements each data source
+//   - All provider schemas exactly match
+//   - All provider meta schemas exactly match
+//   - Only one provider implements each managed resource
+//   - Only one provider implements each data source
 //
 // The various schemas are cached and used to respond to the GetProviderSchema
 // method of the muxed server.

--- a/tf5to6server/doc.go
+++ b/tf5to6server/doc.go
@@ -4,9 +4,9 @@
 // the tfprotov5.ProviderServer (https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov5#ProviderServer)
 // interface, such as:
 //
-//     - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server
-//     - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf5muxserver
-//     - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema
+//   - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server
+//   - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf5muxserver
+//   - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema
 //
 // Refer to the UpgradeServer() function for wrapping a server.
 package tf5to6server

--- a/tf6muxserver/doc.go
+++ b/tf6muxserver/doc.go
@@ -4,9 +4,9 @@
 // the tfprotov6.ProviderServer (https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov6#ProviderServer)
 // interface, such as:
 //
-//     - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework
-//     - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server
-//     - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf5to6server
+//   - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework
+//   - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server
+//   - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf5to6server
 //
 // Refer to the NewMuxServer() function for creating a combined server.
 package tf6muxserver

--- a/tf6muxserver/mux_server.go
+++ b/tf6muxserver/mux_server.go
@@ -39,10 +39,10 @@ func (s muxServer) ProviderServer() tfprotov6.ProviderServer {
 // tfprotov6.ProviderServers specified. The GetProviderSchema method of each
 // is called to verify that the overall muxed server is compatible by ensuring:
 //
-//  - All provider schemas exactly match
-//  - All provider meta schemas exactly match
-//  - Only one provider implements each managed resource
-//  - Only one provider implements each data source
+//   - All provider schemas exactly match
+//   - All provider meta schemas exactly match
+//   - Only one provider implements each managed resource
+//   - Only one provider implements each data source
 //
 // The various schemas are cached and used to respond to the GetProviderSchema
 // method of the muxed server.

--- a/tf6to5server/doc.go
+++ b/tf6to5server/doc.go
@@ -4,9 +4,9 @@
 // the tfprotov6.ProviderServer (https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov6#ProviderServer)
 // interface, such as:
 //
-//     - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework
-//     - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server
-//     - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf6muxserver
+//   - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework
+//   - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server
+//   - https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf6muxserver
 //
 // Refer to the DowngradeServer() function for wrapping a server.
 package tf6to5server

--- a/tf6to5server/tf6to5server.go
+++ b/tf6to5server/tf6to5server.go
@@ -13,8 +13,8 @@ import (
 // version 5 server. Protocol version 5 is not backwards compatible with
 // protocol version 6, so additional validation is performed:
 //
-// - GetProviderSchema is called to ensure SchemaAttribute.NestedType
-//   (nested attributes) are not implemented.
+//   - GetProviderSchema is called to ensure SchemaAttribute.NestedType
+//     (nested attributes) are not implemented.
 //
 // Protocol version 5 servers require Terraform CLI 0.12 or later.
 func DowngradeServer(ctx context.Context, v6server func() tfprotov6.ProviderServer) (tfprotov5.ProviderServer, error) {


### PR DESCRIPTION
To prevent issues with the latest `golangci-lint` in CI.