### PR TITLE
ci: added `forcetypeassert` and `misspell` lint rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,14 +5,15 @@ issues:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - durationcheck
     - errcheck
     - exportloopref
+    - forcetypeassert
     - gofmt
     - gosimple
     - ineffassign
     - makezero
+    - misspell
     - nilerr
     # - paralleltest # Reference: https://github.com/kunwardeep/paralleltest/issues/14
     - predeclared
@@ -20,5 +21,5 @@ linters:
     - tenv
     - unconvert
     - unparam
-    - varcheck
+    - unused
     - vet

--- a/tf5muxserver/mux_server_ApplyResourceChange_test.go
+++ b/tf5muxserver/mux_server_ApplyResourceChange_test.go
@@ -13,19 +13,18 @@ func TestMuxServerApplyResourceChange(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	servers := []func() tfprotov5.ProviderServer{
-		(&tf5testserver.TestServer{
-			ResourceSchemas: map[string]*tfprotov5.Schema{
-				"test_resource_server1": {},
-			},
-		}).ProviderServer,
-		(&tf5testserver.TestServer{
-			ResourceSchemas: map[string]*tfprotov5.Schema{
-				"test_resource_server2": {},
-			},
-		}).ProviderServer,
+	testServer1 := &tf5testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov5.Schema{
+			"test_resource_server1": {},
+		},
+	}
+	testServer2 := &tf5testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov5.Schema{
+			"test_resource_server2": {},
+		},
 	}
 
+	servers := []func() tfprotov5.ProviderServer{testServer1.ProviderServer, testServer2.ProviderServer}
 	muxServer, err := tf5muxserver.NewMuxServer(ctx, servers...)
 
 	if err != nil {
@@ -40,11 +39,11 @@ func TestMuxServerApplyResourceChange(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if !servers[0]().(*tf5testserver.TestServer).ApplyResourceChangeCalled["test_resource_server1"] {
+	if !testServer1.ApplyResourceChangeCalled["test_resource_server1"] {
 		t.Errorf("expected test_resource_server1 ApplyResourceChange to be called on server1")
 	}
 
-	if servers[1]().(*tf5testserver.TestServer).ApplyResourceChangeCalled["test_resource_server1"] {
+	if testServer2.ApplyResourceChangeCalled["test_resource_server1"] {
 		t.Errorf("unexpected test_resource_server1 ApplyResourceChange called on server2")
 	}
 
@@ -56,11 +55,11 @@ func TestMuxServerApplyResourceChange(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if servers[0]().(*tf5testserver.TestServer).ApplyResourceChangeCalled["test_resource_server2"] {
+	if testServer1.ApplyResourceChangeCalled["test_resource_server2"] {
 		t.Errorf("unexpected test_resource_server2 ApplyResourceChange called on server1")
 	}
 
-	if !servers[1]().(*tf5testserver.TestServer).ApplyResourceChangeCalled["test_resource_server2"] {
+	if !testServer2.ApplyResourceChangeCalled["test_resource_server2"] {
 		t.Errorf("expected test_resource_server2 ApplyResourceChange to be called on server2")
 	}
 }

--- a/tf5muxserver/mux_server_ConfigureProvider_test.go
+++ b/tf5muxserver/mux_server_ConfigureProvider_test.go
@@ -12,12 +12,14 @@ import (
 func TestMuxServerConfigureProvider(t *testing.T) {
 	t.Parallel()
 
+	testServers := [5]*tf5testserver.TestServer{{}, {}, {}, {}, {}}
+
 	servers := []func() tfprotov5.ProviderServer{
-		(&tf5testserver.TestServer{}).ProviderServer,
-		(&tf5testserver.TestServer{}).ProviderServer,
-		(&tf5testserver.TestServer{}).ProviderServer,
-		(&tf5testserver.TestServer{}).ProviderServer,
-		(&tf5testserver.TestServer{}).ProviderServer,
+		testServers[0].ProviderServer,
+		testServers[1].ProviderServer,
+		testServers[2].ProviderServer,
+		testServers[3].ProviderServer,
+		testServers[4].ProviderServer,
 	}
 
 	muxServer, err := tf5muxserver.NewMuxServer(context.Background(), servers...)
@@ -32,8 +34,8 @@ func TestMuxServerConfigureProvider(t *testing.T) {
 		t.Fatalf("error calling ConfigureProvider: %s", err)
 	}
 
-	for num, server := range servers {
-		if !server().(*tf5testserver.TestServer).ConfigureProviderCalled {
+	for num, testServer := range testServers {
+		if !testServer.ConfigureProviderCalled {
 			t.Errorf("configure not called on server%d", num+1)
 		}
 	}

--- a/tf5muxserver/mux_server_ImportResourceState_test.go
+++ b/tf5muxserver/mux_server_ImportResourceState_test.go
@@ -13,19 +13,18 @@ func TestMuxServerImportResourceState(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	servers := []func() tfprotov5.ProviderServer{
-		(&tf5testserver.TestServer{
-			ResourceSchemas: map[string]*tfprotov5.Schema{
-				"test_resource_server1": {},
-			},
-		}).ProviderServer,
-		(&tf5testserver.TestServer{
-			ResourceSchemas: map[string]*tfprotov5.Schema{
-				"test_resource_server2": {},
-			},
-		}).ProviderServer,
+	testServer1 := &tf5testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov5.Schema{
+			"test_resource_server1": {},
+		},
+	}
+	testServer2 := &tf5testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov5.Schema{
+			"test_resource_server2": {},
+		},
 	}
 
+	servers := []func() tfprotov5.ProviderServer{testServer1.ProviderServer, testServer2.ProviderServer}
 	muxServer, err := tf5muxserver.NewMuxServer(ctx, servers...)
 
 	if err != nil {
@@ -40,11 +39,11 @@ func TestMuxServerImportResourceState(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if !servers[0]().(*tf5testserver.TestServer).ImportResourceStateCalled["test_resource_server1"] {
+	if !testServer1.ImportResourceStateCalled["test_resource_server1"] {
 		t.Errorf("expected test_resource_server1 ImportResourceState to be called on server1")
 	}
 
-	if servers[1]().(*tf5testserver.TestServer).ImportResourceStateCalled["test_resource_server1"] {
+	if testServer2.ImportResourceStateCalled["test_resource_server1"] {
 		t.Errorf("unexpected test_resource_server1 ImportResourceState called on server2")
 	}
 
@@ -56,11 +55,11 @@ func TestMuxServerImportResourceState(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if servers[0]().(*tf5testserver.TestServer).ImportResourceStateCalled["test_resource_server2"] {
+	if testServer1.ImportResourceStateCalled["test_resource_server2"] {
 		t.Errorf("unexpected test_resource_server2 ImportResourceState called on server1")
 	}
 
-	if !servers[1]().(*tf5testserver.TestServer).ImportResourceStateCalled["test_resource_server2"] {
+	if !testServer2.ImportResourceStateCalled["test_resource_server2"] {
 		t.Errorf("expected test_resource_server2 ImportResourceState to be called on server2")
 	}
 }

--- a/tf5muxserver/mux_server_PlanResourceChange_test.go
+++ b/tf5muxserver/mux_server_PlanResourceChange_test.go
@@ -13,19 +13,19 @@ func TestMuxServerPlanResourceChange(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	servers := []func() tfprotov5.ProviderServer{
-		(&tf5testserver.TestServer{
-			ResourceSchemas: map[string]*tfprotov5.Schema{
-				"test_resource_server1": {},
-			},
-		}).ProviderServer,
-		(&tf5testserver.TestServer{
-			ResourceSchemas: map[string]*tfprotov5.Schema{
-				"test_resource_server2": {},
-			},
-		}).ProviderServer,
+
+	testServer1 := &tf5testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov5.Schema{
+			"test_resource_server1": {},
+		},
+	}
+	testServer2 := &tf5testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov5.Schema{
+			"test_resource_server2": {},
+		},
 	}
 
+	servers := []func() tfprotov5.ProviderServer{testServer1.ProviderServer, testServer2.ProviderServer}
 	muxServer, err := tf5muxserver.NewMuxServer(ctx, servers...)
 
 	if err != nil {
@@ -40,11 +40,11 @@ func TestMuxServerPlanResourceChange(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if !servers[0]().(*tf5testserver.TestServer).PlanResourceChangeCalled["test_resource_server1"] {
+	if !testServer1.PlanResourceChangeCalled["test_resource_server1"] {
 		t.Errorf("expected test_resource_server1 PlanResourceChange to be called on server1")
 	}
 
-	if servers[1]().(*tf5testserver.TestServer).PlanResourceChangeCalled["test_resource_server1"] {
+	if testServer2.PlanResourceChangeCalled["test_resource_server1"] {
 		t.Errorf("unexpected test_resource_server1 PlanResourceChange called on server2")
 	}
 
@@ -56,11 +56,11 @@ func TestMuxServerPlanResourceChange(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if servers[0]().(*tf5testserver.TestServer).PlanResourceChangeCalled["test_resource_server2"] {
+	if testServer1.PlanResourceChangeCalled["test_resource_server2"] {
 		t.Errorf("unexpected test_resource_server2 PlanResourceChange called on server1")
 	}
 
-	if !servers[1]().(*tf5testserver.TestServer).PlanResourceChangeCalled["test_resource_server2"] {
+	if !testServer2.PlanResourceChangeCalled["test_resource_server2"] {
 		t.Errorf("expected test_resource_server2 PlanResourceChange to be called on server2")
 	}
 }

--- a/tf5muxserver/mux_server_PrepareProviderConfig_test.go
+++ b/tf5muxserver/mux_server_PrepareProviderConfig_test.go
@@ -60,13 +60,13 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		servers          []func() tfprotov5.ProviderServer
+		testServers      [3]*tf5testserver.TestServer
 		expectedError    error
 		expectedResponse *tfprotov5.PrepareProviderConfigResponse
 	}{
 		"error-once": {
-			servers: []func() tfprotov5.ProviderServer{
-				(&tf5testserver.TestServer{
+			testServers: [3]*tf5testserver.TestServer{
+				{
 					PrepareProviderConfigResponse: &tfprotov5.PrepareProviderConfigResponse{
 						Diagnostics: []*tfprotov5.Diagnostic{
 							{
@@ -76,9 +76,9 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 							},
 						},
 					},
-				}).ProviderServer,
-				(&tf5testserver.TestServer{}).ProviderServer,
-				(&tf5testserver.TestServer{}).ProviderServer,
+				},
+				{},
+				{},
 			},
 			expectedResponse: &tfprotov5.PrepareProviderConfigResponse{
 				Diagnostics: []*tfprotov5.Diagnostic{
@@ -91,8 +91,8 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 			},
 		},
 		"error-multiple": {
-			servers: []func() tfprotov5.ProviderServer{
-				(&tf5testserver.TestServer{
+			testServers: [3]*tf5testserver.TestServer{
+				{
 					PrepareProviderConfigResponse: &tfprotov5.PrepareProviderConfigResponse{
 						Diagnostics: []*tfprotov5.Diagnostic{
 							{
@@ -102,9 +102,9 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 							},
 						},
 					},
-				}).ProviderServer,
-				(&tf5testserver.TestServer{}).ProviderServer,
-				(&tf5testserver.TestServer{
+				},
+				{},
+				{
 					PrepareProviderConfigResponse: &tfprotov5.PrepareProviderConfigResponse{
 						Diagnostics: []*tfprotov5.Diagnostic{
 							{
@@ -114,7 +114,7 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 							},
 						},
 					},
-				}).ProviderServer,
+				},
 			},
 			expectedResponse: &tfprotov5.PrepareProviderConfigResponse{
 				Diagnostics: []*tfprotov5.Diagnostic{
@@ -132,8 +132,8 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 			},
 		},
 		"warning-once": {
-			servers: []func() tfprotov5.ProviderServer{
-				(&tf5testserver.TestServer{
+			testServers: [3]*tf5testserver.TestServer{
+				{
 					PrepareProviderConfigResponse: &tfprotov5.PrepareProviderConfigResponse{
 						Diagnostics: []*tfprotov5.Diagnostic{
 							{
@@ -143,9 +143,9 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 							},
 						},
 					},
-				}).ProviderServer,
-				(&tf5testserver.TestServer{}).ProviderServer,
-				(&tf5testserver.TestServer{}).ProviderServer,
+				},
+				{},
+				{},
 			},
 			expectedResponse: &tfprotov5.PrepareProviderConfigResponse{
 				Diagnostics: []*tfprotov5.Diagnostic{
@@ -158,8 +158,8 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 			},
 		},
 		"warning-multiple": {
-			servers: []func() tfprotov5.ProviderServer{
-				(&tf5testserver.TestServer{
+			testServers: [3]*tf5testserver.TestServer{
+				{
 					PrepareProviderConfigResponse: &tfprotov5.PrepareProviderConfigResponse{
 						Diagnostics: []*tfprotov5.Diagnostic{
 							{
@@ -169,9 +169,9 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 							},
 						},
 					},
-				}).ProviderServer,
-				(&tf5testserver.TestServer{}).ProviderServer,
-				(&tf5testserver.TestServer{
+				},
+				{},
+				{
 					PrepareProviderConfigResponse: &tfprotov5.PrepareProviderConfigResponse{
 						Diagnostics: []*tfprotov5.Diagnostic{
 							{
@@ -181,7 +181,7 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 							},
 						},
 					},
-				}).ProviderServer,
+				},
 			},
 			expectedResponse: &tfprotov5.PrepareProviderConfigResponse{
 				Diagnostics: []*tfprotov5.Diagnostic{
@@ -199,8 +199,8 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 			},
 		},
 		"warning-then-error": {
-			servers: []func() tfprotov5.ProviderServer{
-				(&tf5testserver.TestServer{
+			testServers: [3]*tf5testserver.TestServer{
+				{
 					PrepareProviderConfigResponse: &tfprotov5.PrepareProviderConfigResponse{
 						Diagnostics: []*tfprotov5.Diagnostic{
 							{
@@ -210,9 +210,9 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 							},
 						},
 					},
-				}).ProviderServer,
-				(&tf5testserver.TestServer{}).ProviderServer,
-				(&tf5testserver.TestServer{
+				},
+				{},
+				{
 					PrepareProviderConfigResponse: &tfprotov5.PrepareProviderConfigResponse{
 						Diagnostics: []*tfprotov5.Diagnostic{
 							{
@@ -222,7 +222,7 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 							},
 						},
 					},
-				}).ProviderServer,
+				},
 			},
 			expectedResponse: &tfprotov5.PrepareProviderConfigResponse{
 				Diagnostics: []*tfprotov5.Diagnostic{
@@ -240,37 +240,37 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 			},
 		},
 		"no-response": {
-			servers: []func() tfprotov5.ProviderServer{
-				(&tf5testserver.TestServer{}).ProviderServer,
-				(&tf5testserver.TestServer{}).ProviderServer,
-				(&tf5testserver.TestServer{}).ProviderServer,
+			testServers: [3]*tf5testserver.TestServer{
+				{},
+				{},
+				{},
 			},
 		},
 		"PreparedConfig-once": {
-			servers: []func() tfprotov5.ProviderServer{
-				(&tf5testserver.TestServer{
+			testServers: [3]*tf5testserver.TestServer{
+				{
 					PrepareProviderConfigResponse: &tfprotov5.PrepareProviderConfigResponse{
 						PreparedConfig: &config,
 					},
 					ProviderSchema: &configSchema,
-				}).ProviderServer,
-				(&tf5testserver.TestServer{}).ProviderServer,
-				(&tf5testserver.TestServer{}).ProviderServer,
+				},
+				{},
+				{},
 			},
 			expectedResponse: &tfprotov5.PrepareProviderConfigResponse{
 				PreparedConfig: &config,
 			},
 		},
 		"PreparedConfig-once-and-error": {
-			servers: []func() tfprotov5.ProviderServer{
-				(&tf5testserver.TestServer{
+			testServers: [3]*tf5testserver.TestServer{
+				{
 					PrepareProviderConfigResponse: &tfprotov5.PrepareProviderConfigResponse{
 						PreparedConfig: &config,
 					},
 					ProviderSchema: &configSchema,
-				}).ProviderServer,
-				(&tf5testserver.TestServer{}).ProviderServer,
-				(&tf5testserver.TestServer{
+				},
+				{},
+				{
 					PrepareProviderConfigResponse: &tfprotov5.PrepareProviderConfigResponse{
 						Diagnostics: []*tfprotov5.Diagnostic{
 							{
@@ -282,7 +282,7 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 						PreparedConfig: &config,
 					},
 					ProviderSchema: &configSchema,
-				}).ProviderServer,
+				},
 			},
 			expectedResponse: &tfprotov5.PrepareProviderConfigResponse{
 				Diagnostics: []*tfprotov5.Diagnostic{
@@ -296,15 +296,15 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 			},
 		},
 		"PreparedConfig-once-and-warning": {
-			servers: []func() tfprotov5.ProviderServer{
-				(&tf5testserver.TestServer{
+			testServers: [3]*tf5testserver.TestServer{
+				{
 					PrepareProviderConfigResponse: &tfprotov5.PrepareProviderConfigResponse{
 						PreparedConfig: &config,
 					},
 					ProviderSchema: &configSchema,
-				}).ProviderServer,
-				(&tf5testserver.TestServer{}).ProviderServer,
-				(&tf5testserver.TestServer{
+				},
+				{},
+				{
 					PrepareProviderConfigResponse: &tfprotov5.PrepareProviderConfigResponse{
 						Diagnostics: []*tfprotov5.Diagnostic{
 							{
@@ -314,7 +314,7 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 							},
 						},
 					},
-				}).ProviderServer,
+				},
 			},
 			expectedResponse: &tfprotov5.PrepareProviderConfigResponse{
 				Diagnostics: []*tfprotov5.Diagnostic{
@@ -328,38 +328,38 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 			},
 		},
 		"PreparedConfig-multiple-different": {
-			servers: []func() tfprotov5.ProviderServer{
-				(&tf5testserver.TestServer{
+			testServers: [3]*tf5testserver.TestServer{
+				{
 					PrepareProviderConfigResponse: &tfprotov5.PrepareProviderConfigResponse{
 						PreparedConfig: &config,
 					},
 					ProviderSchema: &configSchema,
-				}).ProviderServer,
-				(&tf5testserver.TestServer{}).ProviderServer,
-				(&tf5testserver.TestServer{
+				},
+				{},
+				{
 					PrepareProviderConfigResponse: &tfprotov5.PrepareProviderConfigResponse{
 						PreparedConfig: &config2,
 					},
 					ProviderSchema: &configSchema,
-				}).ProviderServer,
+				},
 			},
 			expectedError: fmt.Errorf("got different PrepareProviderConfig PreparedConfig response from multiple servers, not sure which to use"),
 		},
 		"PreparedConfig-multiple-equal": {
-			servers: []func() tfprotov5.ProviderServer{
-				(&tf5testserver.TestServer{
+			testServers: [3]*tf5testserver.TestServer{
+				{
 					PrepareProviderConfigResponse: &tfprotov5.PrepareProviderConfigResponse{
 						PreparedConfig: &config,
 					},
 					ProviderSchema: &configSchema,
-				}).ProviderServer,
-				(&tf5testserver.TestServer{}).ProviderServer,
-				(&tf5testserver.TestServer{
+				},
+				{},
+				{
 					PrepareProviderConfigResponse: &tfprotov5.PrepareProviderConfigResponse{
 						PreparedConfig: &config,
 					},
 					ProviderSchema: &configSchema,
-				}).ProviderServer,
+				},
 			},
 			expectedResponse: &tfprotov5.PrepareProviderConfigResponse{
 				PreparedConfig: &config,
@@ -373,7 +373,13 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			muxServer, err := tf5muxserver.NewMuxServer(context.Background(), testCase.servers...)
+			servers := []func() tfprotov5.ProviderServer{
+				testCase.testServers[0].ProviderServer,
+				testCase.testServers[1].ProviderServer,
+				testCase.testServers[2].ProviderServer,
+			}
+
+			muxServer, err := tf5muxserver.NewMuxServer(context.Background(), servers...)
 
 			if err != nil {
 				t.Fatalf("error setting up muxer: %s", err)
@@ -401,8 +407,8 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 				t.Errorf("unexpected response: %s", cmp.Diff(got, testCase.expectedResponse))
 			}
 
-			for num, server := range testCase.servers {
-				if !server().(*tf5testserver.TestServer).PrepareProviderConfigCalled {
+			for num, testServer := range testCase.testServers {
+				if !testServer.PrepareProviderConfigCalled {
 					t.Errorf("PrepareProviderConfig not called on server%d", num+1)
 				}
 			}

--- a/tf5muxserver/mux_server_ReadDataSource_test.go
+++ b/tf5muxserver/mux_server_ReadDataSource_test.go
@@ -13,19 +13,18 @@ func TestMuxServerReadDataSource(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	servers := []func() tfprotov5.ProviderServer{
-		(&tf5testserver.TestServer{
-			DataSourceSchemas: map[string]*tfprotov5.Schema{
-				"test_data_source_server1": {},
-			},
-		}).ProviderServer,
-		(&tf5testserver.TestServer{
-			DataSourceSchemas: map[string]*tfprotov5.Schema{
-				"test_data_source_server2": {},
-			},
-		}).ProviderServer,
+	testServer1 := &tf5testserver.TestServer{
+		DataSourceSchemas: map[string]*tfprotov5.Schema{
+			"test_data_source_server1": {},
+		},
+	}
+	testServer2 := &tf5testserver.TestServer{
+		DataSourceSchemas: map[string]*tfprotov5.Schema{
+			"test_data_source_server2": {},
+		},
 	}
 
+	servers := []func() tfprotov5.ProviderServer{testServer1.ProviderServer, testServer2.ProviderServer}
 	muxServer, err := tf5muxserver.NewMuxServer(ctx, servers...)
 
 	if err != nil {
@@ -40,11 +39,11 @@ func TestMuxServerReadDataSource(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if !servers[0]().(*tf5testserver.TestServer).ReadDataSourceCalled["test_data_source_server1"] {
+	if !testServer1.ReadDataSourceCalled["test_data_source_server1"] {
 		t.Errorf("expected test_data_source_server1 ReadDataSource to be called on server1")
 	}
 
-	if servers[1]().(*tf5testserver.TestServer).ReadDataSourceCalled["test_data_source_server1"] {
+	if testServer2.ReadDataSourceCalled["test_data_source_server1"] {
 		t.Errorf("unexpected test_data_source_server1 ReadDataSource called on server2")
 	}
 
@@ -56,11 +55,11 @@ func TestMuxServerReadDataSource(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if servers[0]().(*tf5testserver.TestServer).ReadDataSourceCalled["test_data_source_server2"] {
+	if testServer1.ReadDataSourceCalled["test_data_source_server2"] {
 		t.Errorf("unexpected test_data_source_server2 ReadDataSource called on server1")
 	}
 
-	if !servers[1]().(*tf5testserver.TestServer).ReadDataSourceCalled["test_data_source_server2"] {
+	if !testServer2.ReadDataSourceCalled["test_data_source_server2"] {
 		t.Errorf("expected test_data_source_server2 ReadDataSource to be called on server2")
 	}
 }

--- a/tf5muxserver/mux_server_ReadResource_test.go
+++ b/tf5muxserver/mux_server_ReadResource_test.go
@@ -13,19 +13,18 @@ func TestMuxServerReadResource(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	servers := []func() tfprotov5.ProviderServer{
-		(&tf5testserver.TestServer{
-			ResourceSchemas: map[string]*tfprotov5.Schema{
-				"test_resource_server1": {},
-			},
-		}).ProviderServer,
-		(&tf5testserver.TestServer{
-			ResourceSchemas: map[string]*tfprotov5.Schema{
-				"test_resource_server2": {},
-			},
-		}).ProviderServer,
+	testServer1 := &tf5testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov5.Schema{
+			"test_resource_server1": {},
+		},
+	}
+	testServer2 := &tf5testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov5.Schema{
+			"test_resource_server2": {},
+		},
 	}
 
+	servers := []func() tfprotov5.ProviderServer{testServer1.ProviderServer, testServer2.ProviderServer}
 	muxServer, err := tf5muxserver.NewMuxServer(ctx, servers...)
 
 	if err != nil {
@@ -40,11 +39,11 @@ func TestMuxServerReadResource(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if !servers[0]().(*tf5testserver.TestServer).ReadResourceCalled["test_resource_server1"] {
+	if !testServer1.ReadResourceCalled["test_resource_server1"] {
 		t.Errorf("expected test_resource_server1 ReadResource to be called on server1")
 	}
 
-	if servers[1]().(*tf5testserver.TestServer).ReadResourceCalled["test_resource_server1"] {
+	if testServer2.ReadResourceCalled["test_resource_server1"] {
 		t.Errorf("unexpected test_resource_server1 ReadResource called on server2")
 	}
 
@@ -56,11 +55,11 @@ func TestMuxServerReadResource(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if servers[0]().(*tf5testserver.TestServer).ReadResourceCalled["test_resource_server2"] {
+	if testServer1.ReadResourceCalled["test_resource_server2"] {
 		t.Errorf("unexpected test_resource_server2 ReadResource called on server1")
 	}
 
-	if !servers[1]().(*tf5testserver.TestServer).ReadResourceCalled["test_resource_server2"] {
+	if !testServer2.ReadResourceCalled["test_resource_server2"] {
 		t.Errorf("expected test_resource_server2 ReadResource to be called on server2")
 	}
 }

--- a/tf5muxserver/mux_server_StopProvider_test.go
+++ b/tf5muxserver/mux_server_StopProvider_test.go
@@ -12,16 +12,14 @@ import (
 func TestMuxServerStopProvider(t *testing.T) {
 	t.Parallel()
 
+	testServers := [5]*tf5testserver.TestServer{{}, {StopProviderError: "error in server2"}, {}, {StopProviderError: "error in server4"}, {}}
+
 	servers := []func() tfprotov5.ProviderServer{
-		(&tf5testserver.TestServer{}).ProviderServer,
-		(&tf5testserver.TestServer{
-			StopProviderError: "error in server2",
-		}).ProviderServer,
-		(&tf5testserver.TestServer{}).ProviderServer,
-		(&tf5testserver.TestServer{
-			StopProviderError: "error in server4",
-		}).ProviderServer,
-		(&tf5testserver.TestServer{}).ProviderServer,
+		testServers[0].ProviderServer,
+		testServers[1].ProviderServer,
+		testServers[2].ProviderServer,
+		testServers[3].ProviderServer,
+		testServers[4].ProviderServer,
 	}
 
 	muxServer, err := tf5muxserver.NewMuxServer(context.Background(), servers...)
@@ -36,8 +34,8 @@ func TestMuxServerStopProvider(t *testing.T) {
 		t.Fatalf("error calling StopProvider: %s", err)
 	}
 
-	for num, server := range servers {
-		if !server().(*tf5testserver.TestServer).StopProviderCalled {
+	for num, testServer := range testServers {
+		if !testServer.StopProviderCalled {
 			t.Errorf("StopProvider not called on server%d", num+1)
 		}
 	}

--- a/tf5muxserver/mux_server_UpgradeResourceState_test.go
+++ b/tf5muxserver/mux_server_UpgradeResourceState_test.go
@@ -13,19 +13,18 @@ func TestMuxServerUpgradeResourceState(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	servers := []func() tfprotov5.ProviderServer{
-		(&tf5testserver.TestServer{
-			ResourceSchemas: map[string]*tfprotov5.Schema{
-				"test_resource_server1": {},
-			},
-		}).ProviderServer,
-		(&tf5testserver.TestServer{
-			ResourceSchemas: map[string]*tfprotov5.Schema{
-				"test_resource_server2": {},
-			},
-		}).ProviderServer,
+	testServer1 := &tf5testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov5.Schema{
+			"test_resource_server1": {},
+		},
+	}
+	testServer2 := &tf5testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov5.Schema{
+			"test_resource_server2": {},
+		},
 	}
 
+	servers := []func() tfprotov5.ProviderServer{testServer1.ProviderServer, testServer2.ProviderServer}
 	muxServer, err := tf5muxserver.NewMuxServer(ctx, servers...)
 
 	if err != nil {
@@ -40,11 +39,11 @@ func TestMuxServerUpgradeResourceState(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if !servers[0]().(*tf5testserver.TestServer).UpgradeResourceStateCalled["test_resource_server1"] {
+	if !testServer1.UpgradeResourceStateCalled["test_resource_server1"] {
 		t.Errorf("expected test_resource_server1 UpgradeResourceState to be called on server1")
 	}
 
-	if servers[1]().(*tf5testserver.TestServer).UpgradeResourceStateCalled["test_resource_server1"] {
+	if testServer2.UpgradeResourceStateCalled["test_resource_server1"] {
 		t.Errorf("unexpected test_resource_server1 UpgradeResourceState called on server2")
 	}
 
@@ -56,11 +55,11 @@ func TestMuxServerUpgradeResourceState(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if servers[0]().(*tf5testserver.TestServer).UpgradeResourceStateCalled["test_resource_server2"] {
+	if testServer1.UpgradeResourceStateCalled["test_resource_server2"] {
 		t.Errorf("unexpected test_resource_server2 UpgradeResourceState called on server1")
 	}
 
-	if !servers[1]().(*tf5testserver.TestServer).UpgradeResourceStateCalled["test_resource_server2"] {
+	if !testServer2.UpgradeResourceStateCalled["test_resource_server2"] {
 		t.Errorf("expected test_resource_server2 UpgradeResourceState to be called on server2")
 	}
 }

--- a/tf5muxserver/mux_server_ValidateDataSourceConfig_test.go
+++ b/tf5muxserver/mux_server_ValidateDataSourceConfig_test.go
@@ -13,19 +13,18 @@ func TestMuxServerValidateDataSourceConfig(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	servers := []func() tfprotov5.ProviderServer{
-		(&tf5testserver.TestServer{
-			DataSourceSchemas: map[string]*tfprotov5.Schema{
-				"test_data_source_server1": {},
-			},
-		}).ProviderServer,
-		(&tf5testserver.TestServer{
-			DataSourceSchemas: map[string]*tfprotov5.Schema{
-				"test_data_source_server2": {},
-			},
-		}).ProviderServer,
+	testServer1 := &tf5testserver.TestServer{
+		DataSourceSchemas: map[string]*tfprotov5.Schema{
+			"test_data_source_server1": {},
+		},
+	}
+	testServer2 := &tf5testserver.TestServer{
+		DataSourceSchemas: map[string]*tfprotov5.Schema{
+			"test_data_source_server2": {},
+		},
 	}
 
+	servers := []func() tfprotov5.ProviderServer{testServer1.ProviderServer, testServer2.ProviderServer}
 	muxServer, err := tf5muxserver.NewMuxServer(ctx, servers...)
 
 	if err != nil {
@@ -40,11 +39,11 @@ func TestMuxServerValidateDataSourceConfig(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if !servers[0]().(*tf5testserver.TestServer).ValidateDataSourceConfigCalled["test_data_source_server1"] {
+	if !testServer1.ValidateDataSourceConfigCalled["test_data_source_server1"] {
 		t.Errorf("expected test_data_source_server1 ValidateDataSourceConfig to be called on server1")
 	}
 
-	if servers[1]().(*tf5testserver.TestServer).ValidateDataSourceConfigCalled["test_data_source_server1"] {
+	if testServer2.ValidateDataSourceConfigCalled["test_data_source_server1"] {
 		t.Errorf("unexpected test_data_source_server1 ValidateDataSourceConfig called on server2")
 	}
 
@@ -56,11 +55,11 @@ func TestMuxServerValidateDataSourceConfig(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if servers[0]().(*tf5testserver.TestServer).ValidateDataSourceConfigCalled["test_data_source_server2"] {
+	if testServer1.ValidateDataSourceConfigCalled["test_data_source_server2"] {
 		t.Errorf("unexpected test_data_source_server2 ValidateDataSourceConfig called on server1")
 	}
 
-	if !servers[1]().(*tf5testserver.TestServer).ValidateDataSourceConfigCalled["test_data_source_server2"] {
+	if !testServer2.ValidateDataSourceConfigCalled["test_data_source_server2"] {
 		t.Errorf("expected test_data_source_server2 ValidateDataSourceConfig to be called on server2")
 	}
 }

--- a/tf5muxserver/mux_server_ValidateResourceTypeConfig_test.go
+++ b/tf5muxserver/mux_server_ValidateResourceTypeConfig_test.go
@@ -13,19 +13,17 @@ func TestMuxServerValidateResourceTypeConfig(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	servers := []func() tfprotov5.ProviderServer{
-		(&tf5testserver.TestServer{
-			ResourceSchemas: map[string]*tfprotov5.Schema{
-				"test_resource_server1": {},
-			},
-		}).ProviderServer,
-		(&tf5testserver.TestServer{
-			ResourceSchemas: map[string]*tfprotov5.Schema{
-				"test_resource_server2": {},
-			},
-		}).ProviderServer,
+	testServer1 := &tf5testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov5.Schema{
+			"test_resource_server1": {},
+		},
 	}
-
+	testServer2 := &tf5testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov5.Schema{
+			"test_resource_server2": {},
+		},
+	}
+	servers := []func() tfprotov5.ProviderServer{testServer1.ProviderServer, testServer2.ProviderServer}
 	muxServer, err := tf5muxserver.NewMuxServer(ctx, servers...)
 
 	if err != nil {
@@ -40,11 +38,11 @@ func TestMuxServerValidateResourceTypeConfig(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if !servers[0]().(*tf5testserver.TestServer).ValidateResourceTypeConfigCalled["test_resource_server1"] {
+	if !testServer1.ValidateResourceTypeConfigCalled["test_resource_server1"] {
 		t.Errorf("expected test_resource_server1 ValidateResourceTypeConfig to be called on server1")
 	}
 
-	if servers[1]().(*tf5testserver.TestServer).ValidateResourceTypeConfigCalled["test_resource_server1"] {
+	if testServer2.ValidateResourceTypeConfigCalled["test_resource_server1"] {
 		t.Errorf("unexpected test_resource_server1 ValidateResourceTypeConfig called on server2")
 	}
 
@@ -56,11 +54,11 @@ func TestMuxServerValidateResourceTypeConfig(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if servers[0]().(*tf5testserver.TestServer).ValidateResourceTypeConfigCalled["test_resource_server2"] {
+	if testServer1.ValidateResourceTypeConfigCalled["test_resource_server2"] {
 		t.Errorf("unexpected test_resource_server2 ValidateResourceTypeConfig called on server1")
 	}
 
-	if !servers[1]().(*tf5testserver.TestServer).ValidateResourceTypeConfigCalled["test_resource_server2"] {
+	if !testServer2.ValidateResourceTypeConfigCalled["test_resource_server2"] {
 		t.Errorf("expected test_resource_server2 ValidateResourceTypeConfig to be called on server2")
 	}
 }

--- a/tf6muxserver/mux_server_ApplyResourceChange_test.go
+++ b/tf6muxserver/mux_server_ApplyResourceChange_test.go
@@ -13,19 +13,18 @@ func TestMuxServerApplyResourceChange(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	servers := []func() tfprotov6.ProviderServer{
-		(&tf6testserver.TestServer{
-			ResourceSchemas: map[string]*tfprotov6.Schema{
-				"test_resource_server1": {},
-			},
-		}).ProviderServer,
-		(&tf6testserver.TestServer{
-			ResourceSchemas: map[string]*tfprotov6.Schema{
-				"test_resource_server2": {},
-			},
-		}).ProviderServer,
+	testServer1 := &tf6testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov6.Schema{
+			"test_resource_server1": {},
+		},
+	}
+	testServer2 := &tf6testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov6.Schema{
+			"test_resource_server2": {},
+		},
 	}
 
+	servers := []func() tfprotov6.ProviderServer{testServer1.ProviderServer, testServer2.ProviderServer}
 	muxServer, err := tf6muxserver.NewMuxServer(ctx, servers...)
 
 	if err != nil {
@@ -40,11 +39,11 @@ func TestMuxServerApplyResourceChange(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if !servers[0]().(*tf6testserver.TestServer).ApplyResourceChangeCalled["test_resource_server1"] {
+	if !testServer1.ApplyResourceChangeCalled["test_resource_server1"] {
 		t.Errorf("expected test_resource_server1 ApplyResourceChange to be called on server1")
 	}
 
-	if servers[1]().(*tf6testserver.TestServer).ApplyResourceChangeCalled["test_resource_server1"] {
+	if testServer2.ApplyResourceChangeCalled["test_resource_server1"] {
 		t.Errorf("unexpected test_resource_server1 ApplyResourceChange called on server2")
 	}
 
@@ -56,11 +55,11 @@ func TestMuxServerApplyResourceChange(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if servers[0]().(*tf6testserver.TestServer).ApplyResourceChangeCalled["test_resource_server2"] {
+	if testServer1.ApplyResourceChangeCalled["test_resource_server2"] {
 		t.Errorf("unexpected test_resource_server2 ApplyResourceChange called on server1")
 	}
 
-	if !servers[1]().(*tf6testserver.TestServer).ApplyResourceChangeCalled["test_resource_server2"] {
+	if !testServer2.ApplyResourceChangeCalled["test_resource_server2"] {
 		t.Errorf("expected test_resource_server2 ApplyResourceChange to be called on server2")
 	}
 }

--- a/tf6muxserver/mux_server_ConfigureProvider_test.go
+++ b/tf6muxserver/mux_server_ConfigureProvider_test.go
@@ -12,12 +12,14 @@ import (
 func TestMuxServerConfigureProvider(t *testing.T) {
 	t.Parallel()
 
+	testServers := [5]*tf6testserver.TestServer{{}, {}, {}, {}, {}}
+
 	servers := []func() tfprotov6.ProviderServer{
-		(&tf6testserver.TestServer{}).ProviderServer,
-		(&tf6testserver.TestServer{}).ProviderServer,
-		(&tf6testserver.TestServer{}).ProviderServer,
-		(&tf6testserver.TestServer{}).ProviderServer,
-		(&tf6testserver.TestServer{}).ProviderServer,
+		testServers[0].ProviderServer,
+		testServers[1].ProviderServer,
+		testServers[2].ProviderServer,
+		testServers[3].ProviderServer,
+		testServers[4].ProviderServer,
 	}
 
 	muxServer, err := tf6muxserver.NewMuxServer(context.Background(), servers...)
@@ -32,8 +34,8 @@ func TestMuxServerConfigureProvider(t *testing.T) {
 		t.Fatalf("error calling ConfigureProvider: %s", err)
 	}
 
-	for num, server := range servers {
-		if !server().(*tf6testserver.TestServer).ConfigureProviderCalled {
+	for num, testServer := range testServers {
+		if !testServer.ConfigureProviderCalled {
 			t.Errorf("configure not called on server%d", num+1)
 		}
 	}

--- a/tf6muxserver/mux_server_ImportResourceState_test.go
+++ b/tf6muxserver/mux_server_ImportResourceState_test.go
@@ -13,19 +13,18 @@ func TestMuxServerImportResourceState(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	servers := []func() tfprotov6.ProviderServer{
-		(&tf6testserver.TestServer{
-			ResourceSchemas: map[string]*tfprotov6.Schema{
-				"test_resource_server1": {},
-			},
-		}).ProviderServer,
-		(&tf6testserver.TestServer{
-			ResourceSchemas: map[string]*tfprotov6.Schema{
-				"test_resource_server2": {},
-			},
-		}).ProviderServer,
+	testServer1 := &tf6testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov6.Schema{
+			"test_resource_server1": {},
+		},
+	}
+	testServer2 := &tf6testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov6.Schema{
+			"test_resource_server2": {},
+		},
 	}
 
+	servers := []func() tfprotov6.ProviderServer{testServer1.ProviderServer, testServer2.ProviderServer}
 	muxServer, err := tf6muxserver.NewMuxServer(ctx, servers...)
 
 	if err != nil {
@@ -40,11 +39,11 @@ func TestMuxServerImportResourceState(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if !servers[0]().(*tf6testserver.TestServer).ImportResourceStateCalled["test_resource_server1"] {
+	if !testServer1.ImportResourceStateCalled["test_resource_server1"] {
 		t.Errorf("expected test_resource_server1 ImportResourceState to be called on server1")
 	}
 
-	if servers[1]().(*tf6testserver.TestServer).ImportResourceStateCalled["test_resource_server1"] {
+	if testServer2.ImportResourceStateCalled["test_resource_server1"] {
 		t.Errorf("unexpected test_resource_server1 ImportResourceState called on server2")
 	}
 
@@ -56,11 +55,11 @@ func TestMuxServerImportResourceState(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if servers[0]().(*tf6testserver.TestServer).ImportResourceStateCalled["test_resource_server2"] {
+	if testServer1.ImportResourceStateCalled["test_resource_server2"] {
 		t.Errorf("unexpected test_resource_server2 ImportResourceState called on server1")
 	}
 
-	if !servers[1]().(*tf6testserver.TestServer).ImportResourceStateCalled["test_resource_server2"] {
+	if !testServer2.ImportResourceStateCalled["test_resource_server2"] {
 		t.Errorf("expected test_resource_server2 ImportResourceState to be called on server2")
 	}
 }

--- a/tf6muxserver/mux_server_PlanResourceChange_test.go
+++ b/tf6muxserver/mux_server_PlanResourceChange_test.go
@@ -13,19 +13,18 @@ func TestMuxServerPlanResourceChange(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	servers := []func() tfprotov6.ProviderServer{
-		(&tf6testserver.TestServer{
-			ResourceSchemas: map[string]*tfprotov6.Schema{
-				"test_resource_server1": {},
-			},
-		}).ProviderServer,
-		(&tf6testserver.TestServer{
-			ResourceSchemas: map[string]*tfprotov6.Schema{
-				"test_resource_server2": {},
-			},
-		}).ProviderServer,
+	testServer1 := &tf6testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov6.Schema{
+			"test_resource_server1": {},
+		},
+	}
+	testServer2 := &tf6testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov6.Schema{
+			"test_resource_server2": {},
+		},
 	}
 
+	servers := []func() tfprotov6.ProviderServer{testServer1.ProviderServer, testServer2.ProviderServer}
 	muxServer, err := tf6muxserver.NewMuxServer(ctx, servers...)
 
 	if err != nil {
@@ -40,11 +39,11 @@ func TestMuxServerPlanResourceChange(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if !servers[0]().(*tf6testserver.TestServer).PlanResourceChangeCalled["test_resource_server1"] {
+	if !testServer1.PlanResourceChangeCalled["test_resource_server1"] {
 		t.Errorf("expected test_resource_server1 PlanResourceChange to be called on server1")
 	}
 
-	if servers[1]().(*tf6testserver.TestServer).PlanResourceChangeCalled["test_resource_server1"] {
+	if testServer2.PlanResourceChangeCalled["test_resource_server1"] {
 		t.Errorf("unexpected test_resource_server1 PlanResourceChange called on server2")
 	}
 
@@ -56,11 +55,11 @@ func TestMuxServerPlanResourceChange(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if servers[0]().(*tf6testserver.TestServer).PlanResourceChangeCalled["test_resource_server2"] {
+	if testServer1.PlanResourceChangeCalled["test_resource_server2"] {
 		t.Errorf("unexpected test_resource_server2 PlanResourceChange called on server1")
 	}
 
-	if !servers[1]().(*tf6testserver.TestServer).PlanResourceChangeCalled["test_resource_server2"] {
+	if !testServer2.PlanResourceChangeCalled["test_resource_server2"] {
 		t.Errorf("expected test_resource_server2 PlanResourceChange to be called on server2")
 	}
 }

--- a/tf6muxserver/mux_server_ReadDataSource_test.go
+++ b/tf6muxserver/mux_server_ReadDataSource_test.go
@@ -13,19 +13,18 @@ func TestMuxServerReadDataSource(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	servers := []func() tfprotov6.ProviderServer{
-		(&tf6testserver.TestServer{
-			DataSourceSchemas: map[string]*tfprotov6.Schema{
-				"test_data_source_server1": {},
-			},
-		}).ProviderServer,
-		(&tf6testserver.TestServer{
-			DataSourceSchemas: map[string]*tfprotov6.Schema{
-				"test_data_source_server2": {},
-			},
-		}).ProviderServer,
+	testServer1 := &tf6testserver.TestServer{
+		DataSourceSchemas: map[string]*tfprotov6.Schema{
+			"test_data_source_server1": {},
+		},
+	}
+	testServer2 := &tf6testserver.TestServer{
+		DataSourceSchemas: map[string]*tfprotov6.Schema{
+			"test_data_source_server2": {},
+		},
 	}
 
+	servers := []func() tfprotov6.ProviderServer{testServer1.ProviderServer, testServer2.ProviderServer}
 	muxServer, err := tf6muxserver.NewMuxServer(ctx, servers...)
 
 	if err != nil {
@@ -40,11 +39,11 @@ func TestMuxServerReadDataSource(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if !servers[0]().(*tf6testserver.TestServer).ReadDataSourceCalled["test_data_source_server1"] {
+	if !testServer1.ReadDataSourceCalled["test_data_source_server1"] {
 		t.Errorf("expected test_data_source_server1 ReadDataSource to be called on server1")
 	}
 
-	if servers[1]().(*tf6testserver.TestServer).ReadDataSourceCalled["test_data_source_server1"] {
+	if testServer2.ReadDataSourceCalled["test_data_source_server1"] {
 		t.Errorf("unexpected test_data_source_server1 ReadDataSource called on server2")
 	}
 
@@ -56,11 +55,11 @@ func TestMuxServerReadDataSource(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if servers[0]().(*tf6testserver.TestServer).ReadDataSourceCalled["test_data_source_server2"] {
+	if testServer1.ReadDataSourceCalled["test_data_source_server2"] {
 		t.Errorf("unexpected test_data_source_server2 ReadDataSource called on server1")
 	}
 
-	if !servers[1]().(*tf6testserver.TestServer).ReadDataSourceCalled["test_data_source_server2"] {
+	if !testServer2.ReadDataSourceCalled["test_data_source_server2"] {
 		t.Errorf("expected test_data_source_server2 ReadDataSource to be called on server2")
 	}
 }

--- a/tf6muxserver/mux_server_ReadResource_test.go
+++ b/tf6muxserver/mux_server_ReadResource_test.go
@@ -13,19 +13,18 @@ func TestMuxServerReadResource(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	servers := []func() tfprotov6.ProviderServer{
-		(&tf6testserver.TestServer{
-			ResourceSchemas: map[string]*tfprotov6.Schema{
-				"test_resource_server1": {},
-			},
-		}).ProviderServer,
-		(&tf6testserver.TestServer{
-			ResourceSchemas: map[string]*tfprotov6.Schema{
-				"test_resource_server2": {},
-			},
-		}).ProviderServer,
+	testServer1 := &tf6testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov6.Schema{
+			"test_resource_server1": {},
+		},
+	}
+	testServer2 := &tf6testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov6.Schema{
+			"test_resource_server2": {},
+		},
 	}
 
+	servers := []func() tfprotov6.ProviderServer{testServer1.ProviderServer, testServer2.ProviderServer}
 	muxServer, err := tf6muxserver.NewMuxServer(ctx, servers...)
 
 	if err != nil {
@@ -40,11 +39,11 @@ func TestMuxServerReadResource(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if !servers[0]().(*tf6testserver.TestServer).ReadResourceCalled["test_resource_server1"] {
+	if !testServer1.ReadResourceCalled["test_resource_server1"] {
 		t.Errorf("expected test_resource_server1 ReadResource to be called on server1")
 	}
 
-	if servers[1]().(*tf6testserver.TestServer).ReadResourceCalled["test_resource_server1"] {
+	if testServer2.ReadResourceCalled["test_resource_server1"] {
 		t.Errorf("unexpected test_resource_server1 ReadResource called on server2")
 	}
 
@@ -56,11 +55,11 @@ func TestMuxServerReadResource(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if servers[0]().(*tf6testserver.TestServer).ReadResourceCalled["test_resource_server2"] {
+	if testServer1.ReadResourceCalled["test_resource_server2"] {
 		t.Errorf("unexpected test_resource_server2 ReadResource called on server1")
 	}
 
-	if !servers[1]().(*tf6testserver.TestServer).ReadResourceCalled["test_resource_server2"] {
+	if !testServer2.ReadResourceCalled["test_resource_server2"] {
 		t.Errorf("expected test_resource_server2 ReadResource to be called on server2")
 	}
 }

--- a/tf6muxserver/mux_server_StopProvider_test.go
+++ b/tf6muxserver/mux_server_StopProvider_test.go
@@ -12,16 +12,14 @@ import (
 func TestMuxServerStopProvider(t *testing.T) {
 	t.Parallel()
 
+	testServers := [5]*tf6testserver.TestServer{{}, {StopProviderError: "error in server2"}, {}, {StopProviderError: "error in server4"}, {}}
+
 	servers := []func() tfprotov6.ProviderServer{
-		(&tf6testserver.TestServer{}).ProviderServer,
-		(&tf6testserver.TestServer{
-			StopProviderError: "error in server2",
-		}).ProviderServer,
-		(&tf6testserver.TestServer{}).ProviderServer,
-		(&tf6testserver.TestServer{
-			StopProviderError: "error in server4",
-		}).ProviderServer,
-		(&tf6testserver.TestServer{}).ProviderServer,
+		testServers[0].ProviderServer,
+		testServers[1].ProviderServer,
+		testServers[2].ProviderServer,
+		testServers[3].ProviderServer,
+		testServers[4].ProviderServer,
 	}
 
 	muxServer, err := tf6muxserver.NewMuxServer(context.Background(), servers...)
@@ -36,8 +34,8 @@ func TestMuxServerStopProvider(t *testing.T) {
 		t.Fatalf("error calling StopProvider: %s", err)
 	}
 
-	for num, server := range servers {
-		if !server().(*tf6testserver.TestServer).StopProviderCalled {
+	for num, testServer := range testServers {
+		if !testServer.StopProviderCalled {
 			t.Errorf("StopProvider not called on server%d", num+1)
 		}
 	}

--- a/tf6muxserver/mux_server_UpgradeResourceState_test.go
+++ b/tf6muxserver/mux_server_UpgradeResourceState_test.go
@@ -13,19 +13,18 @@ func TestMuxServerUpgradeResourceState(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	servers := []func() tfprotov6.ProviderServer{
-		(&tf6testserver.TestServer{
-			ResourceSchemas: map[string]*tfprotov6.Schema{
-				"test_resource_server1": {},
-			},
-		}).ProviderServer,
-		(&tf6testserver.TestServer{
-			ResourceSchemas: map[string]*tfprotov6.Schema{
-				"test_resource_server2": {},
-			},
-		}).ProviderServer,
+	testServer1 := &tf6testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov6.Schema{
+			"test_resource_server1": {},
+		},
+	}
+	testServer2 := &tf6testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov6.Schema{
+			"test_resource_server2": {},
+		},
 	}
 
+	servers := []func() tfprotov6.ProviderServer{testServer1.ProviderServer, testServer2.ProviderServer}
 	muxServer, err := tf6muxserver.NewMuxServer(ctx, servers...)
 
 	if err != nil {
@@ -40,11 +39,11 @@ func TestMuxServerUpgradeResourceState(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if !servers[0]().(*tf6testserver.TestServer).UpgradeResourceStateCalled["test_resource_server1"] {
+	if !testServer1.UpgradeResourceStateCalled["test_resource_server1"] {
 		t.Errorf("expected test_resource_server1 UpgradeResourceState to be called on server1")
 	}
 
-	if servers[1]().(*tf6testserver.TestServer).UpgradeResourceStateCalled["test_resource_server1"] {
+	if testServer2.UpgradeResourceStateCalled["test_resource_server1"] {
 		t.Errorf("unexpected test_resource_server1 UpgradeResourceState called on server2")
 	}
 
@@ -56,11 +55,11 @@ func TestMuxServerUpgradeResourceState(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if servers[0]().(*tf6testserver.TestServer).UpgradeResourceStateCalled["test_resource_server2"] {
+	if testServer1.UpgradeResourceStateCalled["test_resource_server2"] {
 		t.Errorf("unexpected test_resource_server2 UpgradeResourceState called on server1")
 	}
 
-	if !servers[1]().(*tf6testserver.TestServer).UpgradeResourceStateCalled["test_resource_server2"] {
+	if !testServer2.UpgradeResourceStateCalled["test_resource_server2"] {
 		t.Errorf("expected test_resource_server2 UpgradeResourceState to be called on server2")
 	}
 }

--- a/tf6muxserver/mux_server_ValidateDataResourceConfig_test.go
+++ b/tf6muxserver/mux_server_ValidateDataResourceConfig_test.go
@@ -13,19 +13,18 @@ func TestMuxServerValidateDataResourceConfig(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	servers := []func() tfprotov6.ProviderServer{
-		(&tf6testserver.TestServer{
-			DataSourceSchemas: map[string]*tfprotov6.Schema{
-				"test_data_source_server1": {},
-			},
-		}).ProviderServer,
-		(&tf6testserver.TestServer{
-			DataSourceSchemas: map[string]*tfprotov6.Schema{
-				"test_data_source_server2": {},
-			},
-		}).ProviderServer,
+	testServer1 := &tf6testserver.TestServer{
+		DataSourceSchemas: map[string]*tfprotov6.Schema{
+			"test_data_source_server1": {},
+		},
+	}
+	testServer2 := &tf6testserver.TestServer{
+		DataSourceSchemas: map[string]*tfprotov6.Schema{
+			"test_data_source_server2": {},
+		},
 	}
 
+	servers := []func() tfprotov6.ProviderServer{testServer1.ProviderServer, testServer2.ProviderServer}
 	muxServer, err := tf6muxserver.NewMuxServer(ctx, servers...)
 
 	if err != nil {
@@ -40,11 +39,11 @@ func TestMuxServerValidateDataResourceConfig(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if !servers[0]().(*tf6testserver.TestServer).ValidateDataResourceConfigCalled["test_data_source_server1"] {
+	if !testServer1.ValidateDataResourceConfigCalled["test_data_source_server1"] {
 		t.Errorf("expected test_data_source_server1 ValidateDataResourceConfig to be called on server1")
 	}
 
-	if servers[1]().(*tf6testserver.TestServer).ValidateDataResourceConfigCalled["test_data_source_server1"] {
+	if testServer2.ValidateDataResourceConfigCalled["test_data_source_server1"] {
 		t.Errorf("unexpected test_data_source_server1 ValidateDataResourceConfig called on server2")
 	}
 
@@ -56,11 +55,11 @@ func TestMuxServerValidateDataResourceConfig(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if servers[0]().(*tf6testserver.TestServer).ValidateDataResourceConfigCalled["test_data_source_server2"] {
+	if testServer1.ValidateDataResourceConfigCalled["test_data_source_server2"] {
 		t.Errorf("unexpected test_data_source_server2 ValidateDataResourceConfig called on server1")
 	}
 
-	if !servers[1]().(*tf6testserver.TestServer).ValidateDataResourceConfigCalled["test_data_source_server2"] {
+	if !testServer2.ValidateDataResourceConfigCalled["test_data_source_server2"] {
 		t.Errorf("expected test_data_source_server2 ValidateDataResourceConfig to be called on server2")
 	}
 }

--- a/tf6muxserver/mux_server_ValidateProviderConfig_test.go
+++ b/tf6muxserver/mux_server_ValidateProviderConfig_test.go
@@ -60,12 +60,12 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		testServers      [3]tf6testserver.TestServer
+		testServers      [3]*tf6testserver.TestServer
 		expectedError    error
 		expectedResponse *tfprotov6.ValidateProviderConfigResponse
 	}{
 		"error-once": {
-			testServers: [3]tf6testserver.TestServer{
+			testServers: [3]*tf6testserver.TestServer{
 				{
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						Diagnostics: []*tfprotov6.Diagnostic{
@@ -91,7 +91,7 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 			},
 		},
 		"error-multiple": {
-			testServers: [3]tf6testserver.TestServer{
+			testServers: [3]*tf6testserver.TestServer{
 				{
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						Diagnostics: []*tfprotov6.Diagnostic{
@@ -132,7 +132,7 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 			},
 		},
 		"warning-once": {
-			testServers: [3]tf6testserver.TestServer{
+			testServers: [3]*tf6testserver.TestServer{
 				{
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						Diagnostics: []*tfprotov6.Diagnostic{
@@ -158,7 +158,7 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 			},
 		},
 		"warning-multiple": {
-			testServers: [3]tf6testserver.TestServer{
+			testServers: [3]*tf6testserver.TestServer{
 				{
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						Diagnostics: []*tfprotov6.Diagnostic{
@@ -199,7 +199,7 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 			},
 		},
 		"warning-then-error": {
-			testServers: [3]tf6testserver.TestServer{
+			testServers: [3]*tf6testserver.TestServer{
 				{
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						Diagnostics: []*tfprotov6.Diagnostic{
@@ -240,14 +240,14 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 			},
 		},
 		"no-response": {
-			testServers: [3]tf6testserver.TestServer{
+			testServers: [3]*tf6testserver.TestServer{
 				{},
 				{},
 				{},
 			},
 		},
 		"PreparedConfig-once": {
-			testServers: [3]tf6testserver.TestServer{
+			testServers: [3]*tf6testserver.TestServer{
 				{
 					ProviderSchema: &configSchema,
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
@@ -262,7 +262,7 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 			},
 		},
 		"PreparedConfig-once-and-error": {
-			testServers: [3]tf6testserver.TestServer{
+			testServers: [3]*tf6testserver.TestServer{
 				{
 					ProviderSchema: &configSchema,
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
@@ -297,7 +297,7 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 			},
 		},
 		"PreparedConfig-once-and-warning": {
-			testServers: [3]tf6testserver.TestServer{
+			testServers: [3]*tf6testserver.TestServer{
 				{
 					ProviderSchema: &configSchema,
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
@@ -332,7 +332,7 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 			},
 		},
 		"PreparedConfig-multiple-different": {
-			testServers: [3]tf6testserver.TestServer{
+			testServers: [3]*tf6testserver.TestServer{
 				{
 					ProviderSchema: &configSchema,
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
@@ -352,7 +352,7 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 			expectedError: fmt.Errorf("got different PrepareProviderConfig PreparedConfig response from multiple servers, not sure which to use"),
 		},
 		"PreparedConfig-multiple-equal": {
-			testServers: [3]tf6testserver.TestServer{
+			testServers: [3]*tf6testserver.TestServer{
 				{
 					ProviderSchema: &configSchema,
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{

--- a/tf6muxserver/mux_server_ValidateProviderConfig_test.go
+++ b/tf6muxserver/mux_server_ValidateProviderConfig_test.go
@@ -60,13 +60,13 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		servers          []func() tfprotov6.ProviderServer
+		testServers      [3]tf6testserver.TestServer
 		expectedError    error
 		expectedResponse *tfprotov6.ValidateProviderConfigResponse
 	}{
 		"error-once": {
-			servers: []func() tfprotov6.ProviderServer{
-				(&tf6testserver.TestServer{
+			testServers: [3]tf6testserver.TestServer{
+				{
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						Diagnostics: []*tfprotov6.Diagnostic{
 							{
@@ -76,9 +76,9 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 							},
 						},
 					},
-				}).ProviderServer,
-				(&tf6testserver.TestServer{}).ProviderServer,
-				(&tf6testserver.TestServer{}).ProviderServer,
+				},
+				{},
+				{},
 			},
 			expectedResponse: &tfprotov6.ValidateProviderConfigResponse{
 				Diagnostics: []*tfprotov6.Diagnostic{
@@ -91,8 +91,8 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 			},
 		},
 		"error-multiple": {
-			servers: []func() tfprotov6.ProviderServer{
-				(&tf6testserver.TestServer{
+			testServers: [3]tf6testserver.TestServer{
+				{
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						Diagnostics: []*tfprotov6.Diagnostic{
 							{
@@ -102,9 +102,9 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 							},
 						},
 					},
-				}).ProviderServer,
-				(&tf6testserver.TestServer{}).ProviderServer,
-				(&tf6testserver.TestServer{
+				},
+				{},
+				{
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						Diagnostics: []*tfprotov6.Diagnostic{
 							{
@@ -114,7 +114,7 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 							},
 						},
 					},
-				}).ProviderServer,
+				},
 			},
 			expectedResponse: &tfprotov6.ValidateProviderConfigResponse{
 				Diagnostics: []*tfprotov6.Diagnostic{
@@ -132,8 +132,8 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 			},
 		},
 		"warning-once": {
-			servers: []func() tfprotov6.ProviderServer{
-				(&tf6testserver.TestServer{
+			testServers: [3]tf6testserver.TestServer{
+				{
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						Diagnostics: []*tfprotov6.Diagnostic{
 							{
@@ -143,9 +143,9 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 							},
 						},
 					},
-				}).ProviderServer,
-				(&tf6testserver.TestServer{}).ProviderServer,
-				(&tf6testserver.TestServer{}).ProviderServer,
+				},
+				{},
+				{},
 			},
 			expectedResponse: &tfprotov6.ValidateProviderConfigResponse{
 				Diagnostics: []*tfprotov6.Diagnostic{
@@ -158,8 +158,8 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 			},
 		},
 		"warning-multiple": {
-			servers: []func() tfprotov6.ProviderServer{
-				(&tf6testserver.TestServer{
+			testServers: [3]tf6testserver.TestServer{
+				{
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						Diagnostics: []*tfprotov6.Diagnostic{
 							{
@@ -169,9 +169,9 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 							},
 						},
 					},
-				}).ProviderServer,
-				(&tf6testserver.TestServer{}).ProviderServer,
-				(&tf6testserver.TestServer{
+				},
+				{},
+				{
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						Diagnostics: []*tfprotov6.Diagnostic{
 							{
@@ -181,7 +181,7 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 							},
 						},
 					},
-				}).ProviderServer,
+				},
 			},
 			expectedResponse: &tfprotov6.ValidateProviderConfigResponse{
 				Diagnostics: []*tfprotov6.Diagnostic{
@@ -199,8 +199,8 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 			},
 		},
 		"warning-then-error": {
-			servers: []func() tfprotov6.ProviderServer{
-				(&tf6testserver.TestServer{
+			testServers: [3]tf6testserver.TestServer{
+				{
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						Diagnostics: []*tfprotov6.Diagnostic{
 							{
@@ -210,9 +210,9 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 							},
 						},
 					},
-				}).ProviderServer,
-				(&tf6testserver.TestServer{}).ProviderServer,
-				(&tf6testserver.TestServer{
+				},
+				{},
+				{
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						Diagnostics: []*tfprotov6.Diagnostic{
 							{
@@ -222,7 +222,7 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 							},
 						},
 					},
-				}).ProviderServer,
+				},
 			},
 			expectedResponse: &tfprotov6.ValidateProviderConfigResponse{
 				Diagnostics: []*tfprotov6.Diagnostic{
@@ -240,39 +240,39 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 			},
 		},
 		"no-response": {
-			servers: []func() tfprotov6.ProviderServer{
-				(&tf6testserver.TestServer{}).ProviderServer,
-				(&tf6testserver.TestServer{}).ProviderServer,
-				(&tf6testserver.TestServer{}).ProviderServer,
+			testServers: [3]tf6testserver.TestServer{
+				{},
+				{},
+				{},
 			},
 		},
 		"PreparedConfig-once": {
-			servers: []func() tfprotov6.ProviderServer{
-				(&tf6testserver.TestServer{
+			testServers: [3]tf6testserver.TestServer{
+				{
 					ProviderSchema: &configSchema,
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						PreparedConfig: &config,
 					},
-				}).ProviderServer,
-				(&tf6testserver.TestServer{}).ProviderServer,
-				(&tf6testserver.TestServer{}).ProviderServer,
+				},
+				{},
+				{},
 			},
 			expectedResponse: &tfprotov6.ValidateProviderConfigResponse{
 				PreparedConfig: &config,
 			},
 		},
 		"PreparedConfig-once-and-error": {
-			servers: []func() tfprotov6.ProviderServer{
-				(&tf6testserver.TestServer{
+			testServers: [3]tf6testserver.TestServer{
+				{
 					ProviderSchema: &configSchema,
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						PreparedConfig: &config,
 					},
-				}).ProviderServer,
-				(&tf6testserver.TestServer{
+				},
+				{
 					ProviderSchema: &configSchema,
-				}).ProviderServer,
-				(&tf6testserver.TestServer{
+				},
+				{
 					ProviderSchema: &configSchema,
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						Diagnostics: []*tfprotov6.Diagnostic{
@@ -283,7 +283,7 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 							},
 						},
 					},
-				}).ProviderServer,
+				},
 			},
 			expectedResponse: &tfprotov6.ValidateProviderConfigResponse{
 				Diagnostics: []*tfprotov6.Diagnostic{
@@ -297,17 +297,17 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 			},
 		},
 		"PreparedConfig-once-and-warning": {
-			servers: []func() tfprotov6.ProviderServer{
-				(&tf6testserver.TestServer{
+			testServers: [3]tf6testserver.TestServer{
+				{
 					ProviderSchema: &configSchema,
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						PreparedConfig: &config,
 					},
-				}).ProviderServer,
-				(&tf6testserver.TestServer{
+				},
+				{
 					ProviderSchema: &configSchema,
-				}).ProviderServer,
-				(&tf6testserver.TestServer{
+				},
+				{
 					ProviderSchema: &configSchema,
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						Diagnostics: []*tfprotov6.Diagnostic{
@@ -318,7 +318,7 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 							},
 						},
 					},
-				}).ProviderServer,
+				},
 			},
 			expectedResponse: &tfprotov6.ValidateProviderConfigResponse{
 				Diagnostics: []*tfprotov6.Diagnostic{
@@ -332,42 +332,42 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 			},
 		},
 		"PreparedConfig-multiple-different": {
-			servers: []func() tfprotov6.ProviderServer{
-				(&tf6testserver.TestServer{
+			testServers: [3]tf6testserver.TestServer{
+				{
 					ProviderSchema: &configSchema,
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						PreparedConfig: &config,
 					},
-				}).ProviderServer,
-				(&tf6testserver.TestServer{
+				},
+				{
 					ProviderSchema: &configSchema,
-				}).ProviderServer,
-				(&tf6testserver.TestServer{
+				},
+				{
 					ProviderSchema: &configSchema,
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						PreparedConfig: &config2,
 					},
-				}).ProviderServer,
+				},
 			},
 			expectedError: fmt.Errorf("got different PrepareProviderConfig PreparedConfig response from multiple servers, not sure which to use"),
 		},
 		"PreparedConfig-multiple-equal": {
-			servers: []func() tfprotov6.ProviderServer{
-				(&tf6testserver.TestServer{
+			testServers: [3]tf6testserver.TestServer{
+				{
 					ProviderSchema: &configSchema,
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						PreparedConfig: &config,
 					},
-				}).ProviderServer,
-				(&tf6testserver.TestServer{
+				},
+				{
 					ProviderSchema: &configSchema,
-				}).ProviderServer,
-				(&tf6testserver.TestServer{
+				},
+				{
 					ProviderSchema: &configSchema,
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						PreparedConfig: &config,
 					},
-				}).ProviderServer,
+				},
 			},
 			expectedResponse: &tfprotov6.ValidateProviderConfigResponse{
 				PreparedConfig: &config,
@@ -381,7 +381,13 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			muxServer, err := tf6muxserver.NewMuxServer(context.Background(), testCase.servers...)
+			servers := []func() tfprotov6.ProviderServer{
+				testCase.testServers[0].ProviderServer,
+				testCase.testServers[1].ProviderServer,
+				testCase.testServers[2].ProviderServer,
+			}
+
+			muxServer, err := tf6muxserver.NewMuxServer(context.Background(), servers...)
 
 			if err != nil {
 				t.Fatalf("error setting up muxer: %s", err)
@@ -409,8 +415,8 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 				t.Errorf("unexpected response: %s", cmp.Diff(got, testCase.expectedResponse))
 			}
 
-			for num, server := range testCase.servers {
-				if !server().(*tf6testserver.TestServer).ValidateProviderConfigCalled {
+			for num, testServer := range testCase.testServers {
+				if !testServer.ValidateProviderConfigCalled {
 					t.Errorf("ValidateProviderConfig not called on server%d", num+1)
 				}
 			}

--- a/tf6muxserver/mux_server_ValidateResourceConfig_test.go
+++ b/tf6muxserver/mux_server_ValidateResourceConfig_test.go
@@ -13,19 +13,18 @@ func TestMuxServerValidateResourceConfig(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	servers := []func() tfprotov6.ProviderServer{
-		(&tf6testserver.TestServer{
-			ResourceSchemas: map[string]*tfprotov6.Schema{
-				"test_resource_server1": {},
-			},
-		}).ProviderServer,
-		(&tf6testserver.TestServer{
-			ResourceSchemas: map[string]*tfprotov6.Schema{
-				"test_resource_server2": {},
-			},
-		}).ProviderServer,
+	testServer1 := &tf6testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov6.Schema{
+			"test_resource_server1": {},
+		},
+	}
+	testServer2 := &tf6testserver.TestServer{
+		ResourceSchemas: map[string]*tfprotov6.Schema{
+			"test_resource_server2": {},
+		},
 	}
 
+	servers := []func() tfprotov6.ProviderServer{testServer1.ProviderServer, testServer2.ProviderServer}
 	muxServer, err := tf6muxserver.NewMuxServer(ctx, servers...)
 
 	if err != nil {
@@ -40,11 +39,11 @@ func TestMuxServerValidateResourceConfig(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if !servers[0]().(*tf6testserver.TestServer).ValidateResourceConfigCalled["test_resource_server1"] {
+	if !testServer1.ValidateResourceConfigCalled["test_resource_server1"] {
 		t.Errorf("expected test_resource_server1 ValidateResourceConfig to be called on server1")
 	}
 
-	if servers[1]().(*tf6testserver.TestServer).ValidateResourceConfigCalled["test_resource_server1"] {
+	if testServer2.ValidateResourceConfigCalled["test_resource_server1"] {
 		t.Errorf("unexpected test_resource_server1 ValidateResourceConfig called on server2")
 	}
 
@@ -56,11 +55,11 @@ func TestMuxServerValidateResourceConfig(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if servers[0]().(*tf6testserver.TestServer).ValidateResourceConfigCalled["test_resource_server2"] {
+	if testServer1.ValidateResourceConfigCalled["test_resource_server2"] {
 		t.Errorf("unexpected test_resource_server2 ValidateResourceConfig called on server1")
 	}
 
-	if !servers[1]().(*tf6testserver.TestServer).ValidateResourceConfigCalled["test_resource_server2"] {
+	if !testServer2.ValidateResourceConfigCalled["test_resource_server2"] {
 		t.Errorf("expected test_resource_server2 ValidateResourceConfig to be called on server2")
 	}
 }


### PR DESCRIPTION
contributes to: https://github.com/hashicorp/terraform-providers-devex-internal/issues/102 + https://github.com/hashicorp/terraform-providers-devex-internal/issues/83

### Notes
- `deadcode` and `varcheck` linters are deprecated in **golangci-lint** in favor of `unused`
```bash
 $ golangci-lint run
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
```