### PR TITLE
docs: Migrate link formats

### DIFF
--- a/website/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/website/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -6,12 +6,12 @@ description: >-
 
 # Combining Protocol Version 5 Providers
 
-The [`tf5muxserver`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf5muxserver) package enables combining any number of [protocol version 5 provider servers](/plugin/how-terraform-works#protocol-version-5) into a single server.
+The [`tf5muxserver`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf5muxserver) package enables combining any number of [protocol version 5 provider servers](/terraform/plugin/how-terraform-works#protocol-version-5) into a single server.
 
 Use this package to:
 
 * Support multiple development teams across separate codebases.
-* Support multiple provider SDK implementations. For example, you could downgrade an existing [terraform-plugin-framework](/plugin/framework) provider to protocol version 5 and then combine it with one or more providers built with [terraform-plugin-sdk/v2](/plugin/sdkv2).
+* Support multiple provider SDK implementations. For example, you could downgrade an existing [terraform-plugin-framework](/terraform/plugin/framework) provider to protocol version 5 and then combine it with one or more providers built with [terraform-plugin-sdk/v2](/terraform/plugin/sdkv2).
 
 ## Compatibility
 
@@ -19,9 +19,9 @@ Protocol version 5 provider servers are compatible with Terraform CLI 0.12 and l
 
 The following provider server implementations are supported:
 
-* [terraform-plugin-sdk/v2](/plugin/sdkv2): A higher-level SDK that makes Terraform provider development easier by abstracting implementation details.
+* [terraform-plugin-sdk/v2](/terraform/plugin/sdkv2): A higher-level SDK that makes Terraform provider development easier by abstracting implementation details.
 * [terraform-plugin-go tf5server](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server): A lower-level SDK to develop Terraform providers for more advanced use cases.
-* [tf6to5server](/plugin/mux/translating-protocol-version-6-to-5): A package to translate protocol version 6 providers into protocol version 5.
+* [tf6to5server](/terraform/plugin/mux/translating-protocol-version-6-to-5): A package to translate protocol version 6 providers into protocol version 5.
 
 ## Requirements
 
@@ -31,7 +31,7 @@ To be combined, provider servers must meet the following requirements:
 * All provider meta schemas must match.
 * Only one provider may implement each resource and data source.
 
-If publishing to the [Terraform Registry](/registry), set `metadata.protocol_versions` to `["5.0"]` in the [Terraform Registry manifest file](/registry/providers/publishing#terraform-registry-manifest-file).
+If publishing to the [Terraform Registry](/terraform/registry), set `metadata.protocol_versions` to `["5.0"]` in the [Terraform Registry manifest file](/terraform/registry/providers/publishing#terraform-registry-manifest-file).
 
 ## Code Implementation
 
@@ -96,7 +96,7 @@ func main() {
 
 ## Testing Implementation
 
-You can test individual providers using the same [acceptance tests](/plugin/sdkv2/testing/acceptance-tests) as before. Set the [`ProtoV5ProviderFactories` field of `TestCase`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#TestCase.ProtoV5ProviderFactories) to use the acceptance testing framework available in [terraform-provider-sdk/v2/helper/resource](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource). 
+You can test individual providers using the same [acceptance tests](/terraform/plugin/sdkv2/testing/acceptance-tests) as before. Set the [`ProtoV5ProviderFactories` field of `TestCase`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#TestCase.ProtoV5ProviderFactories) to use the acceptance testing framework available in [terraform-provider-sdk/v2/helper/resource](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource). 
 
 The following example uses the acceptance testing framework to create a test for two providers.
 
@@ -124,4 +124,4 @@ resource.Test(t, resource.TestCase{
 })
 ```
 
-Refer to the [acceptance tests](/plugin/sdkv2/testing/acceptance-tests) documentation for more details.
+Refer to the [acceptance tests](/terraform/plugin/sdkv2/testing/acceptance-tests) documentation for more details.

--- a/website/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/website/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -6,12 +6,12 @@ description: >-
 
 # Combining Protocol Version 6 Providers
 
-The [`tf6muxserver`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf6muxserver) package enables combining any number of [protocol version 6 provider servers](/plugin/how-terraform-works#protocol-version-6) into a single server.
+The [`tf6muxserver`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf6muxserver) package enables combining any number of [protocol version 6 provider servers](/terraform/plugin/how-terraform-works#protocol-version-6) into a single server.
 
 Use this package to:
 
 * Support multiple development teams across separate codebases.
-* Support multiple provider SDK implementations. For example, you could upgrade an existing [terraform-plugin-sdk/v2](/plugin/sdkv2) provider to protocol version 6 and then combine it with one or more providers built with [terraform-plugin-framework](/plugin/framework).
+* Support multiple provider SDK implementations. For example, you could upgrade an existing [terraform-plugin-sdk/v2](/terraform/plugin/sdkv2) provider to protocol version 6 and then combine it with one or more providers built with [terraform-plugin-framework](/terraform/plugin/framework).
 
 ## Compatibility
 
@@ -19,9 +19,9 @@ Protocol version 6 provider servers are compatible with Terraform CLI 1.0 and la
 
 The following provider server implementations are supported:
 
-* [terraform-plugin-framework](/plugin/framework): A higher-level SDK that makes Terraform provider development easier by abstracting implementation details.
+* [terraform-plugin-framework](/terraform/plugin/framework): A higher-level SDK that makes Terraform provider development easier by abstracting implementation details.
 * [terraform-plugin-go tf6server](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server): A lower-level SDK to develop Terraform providers for more advanced use cases.
-* [tf5to6server](/plugin/mux/translating-protocol-version-5-to-6): A package to translate protocol version 5 providers into protocol version 6.
+* [tf5to6server](/terraform/plugin/mux/translating-protocol-version-5-to-6): A package to translate protocol version 5 providers into protocol version 6.
 
 ## Requirements
 
@@ -31,7 +31,7 @@ To be combined, provider servers must meet the following requirements:
 * All provider meta schemas must match.
 * Only one provider may implement each resource and data source.
 
-If publishing to the [Terraform Registry](/registry), set `metadata.protocol_versions` to `["6.0"]` in the [Terraform Registry manifest file](/registry/providers/publishing#terraform-registry-manifest-file).
+If publishing to the [Terraform Registry](/terraform/registry), set `metadata.protocol_versions` to `["6.0"]` in the [Terraform Registry manifest file](/terraform/registry/providers/publishing#terraform-registry-manifest-file).
 
 ## Code Implementation
 
@@ -97,7 +97,7 @@ func main() {
 
 ## Testing Implementation
 
-You can test individual providers using the same [acceptance tests](/plugin/sdkv2/testing/acceptance-tests) as before. Set the [`ProtoV6ProviderFactories` field of `TestCase`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#TestCase.ProtoV6ProviderFactories) to use the acceptance testing framework available in [terraform-provider-sdk/v2/helper/resource](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource).
+You can test individual providers using the same [acceptance tests](/terraform/plugin/sdkv2/testing/acceptance-tests) as before. Set the [`ProtoV6ProviderFactories` field of `TestCase`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#TestCase.ProtoV6ProviderFactories) to use the acceptance testing framework available in [terraform-provider-sdk/v2/helper/resource](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource).
 
 The following example uses the acceptance testing framework to create a test for two providers.
 
@@ -125,4 +125,4 @@ resource.Test(t, resource.TestCase{
 })
 ```
 
-Refer to the [acceptance tests](/plugin/sdkv2/testing/acceptance-tests) documentation for more details.
+Refer to the [acceptance tests](/terraform/plugin/sdkv2/testing/acceptance-tests) documentation for more details.

--- a/website/docs/plugin/mux/index.mdx
+++ b/website/docs/plugin/mux/index.mdx
@@ -6,29 +6,29 @@ description: >-
 
 # Combining and Translating Providers
 
-The [terraform-plugin-mux](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux) Go module is a collection of Go packages for combining (multiplexing) and translating provider servers. It helps minimize provider code changes by wrapping existing provider servers. This functionality is based on the [Terraform Plugin Protocol](/plugin/how-terraform-works#terraform-plugin-protocol) and [`terraform-plugin-go`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go) provider servers.
+The [terraform-plugin-mux](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux) Go module is a collection of Go packages for combining (multiplexing) and translating provider servers. It helps minimize provider code changes by wrapping existing provider servers. This functionality is based on the [Terraform Plugin Protocol](/terraform/plugin/how-terraform-works#terraform-plugin-protocol) and [`terraform-plugin-go`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go) provider servers.
 
 ## Use Cases
 
 The `terraform-plugin-mux` Go module enables flexibility when you develop and maintain Terraform providers. It is especially useful when you need to upgrade an existing provider to use the plugin framework SDK or the latest version of the plugin protocol. We recommend using `terraform-plugin-mux` for the following use cases:
 
 - Combine providers to reduce maintenance burden while still supporting varying Terraform requirements or multiple provider SDK implementations.
-- Migrate resources and data sources from [terraform-plugin-sdk/v2](/plugin/sdkv2) to [terraform-plugin-framework](/plugin/framework) over time.
-- Develop with [terraform-plugin-sdk/v2](/plugin/sdkv2), but require Terraform CLI 1.0 or later.
-- Develop with [terraform-plugin-framework](/plugin/framework), but support Terraform CLI 0.12 or later.
+- Migrate resources and data sources from [terraform-plugin-sdk/v2](/terraform/plugin/sdkv2) to [terraform-plugin-framework](/terraform/plugin/framework) over time.
+- Develop with [terraform-plugin-sdk/v2](/terraform/plugin/sdkv2), but require Terraform CLI 1.0 or later.
+- Develop with [terraform-plugin-framework](/terraform/plugin/framework), but support Terraform CLI 0.12 or later.
 
 ## Combine Protocol 6 Providers
 
-Use the [tf6muxserver](/plugin/mux/combining-protocol-version-6-providers) package to combine any number of [protocol version 6 provider servers](/plugin/how-terraform-works#protocol-version-6) into a single server.
+Use the [tf6muxserver](/terraform/plugin/mux/combining-protocol-version-6-providers) package to combine any number of [protocol version 6 provider servers](/terraform/plugin/how-terraform-works#protocol-version-6) into a single server.
 
 ## Combine Protocol 5 Providers
 
-Use the [tf5muxserver](/plugin/mux/combining-protocol-version-5-providers) package to combine any number of [protocol version 5 provider servers](/plugin/how-terraform-works#protocol-version-5) into a single server.
+Use the [tf5muxserver](/terraform/plugin/mux/combining-protocol-version-5-providers) package to combine any number of [protocol version 5 provider servers](/terraform/plugin/how-terraform-works#protocol-version-5) into a single server.
 
 ## Translate Protocol 5 Providers to Protocol 6
 
-Use the [tf5to6server](/plugin/mux/translating-protocol-version-5-to-6) package to translate a [protocol version 5 provider server](/plugin/how-terraform-works#protocol-version-5) into a [protocol version 6 provider server](/plugin/how-terraform-works#protocol-version-6).
+Use the [tf5to6server](/terraform/plugin/mux/translating-protocol-version-5-to-6) package to translate a [protocol version 5 provider server](/terraform/plugin/how-terraform-works#protocol-version-5) into a [protocol version 6 provider server](/terraform/plugin/how-terraform-works#protocol-version-6).
 
 ## Translate Protocol 6 Providers to Protocol 5
 
-Use the [tf6to5server](/plugin/mux/translating-protocol-version-6-to-5) package to translate a [protocol version 6 provider server](/plugin/how-terraform-works#protocol-version-6) into a [protocol version 5 provider server](/plugin/how-terraform-works#protocol-version-5).
+Use the [tf6to5server](/terraform/plugin/mux/translating-protocol-version-6-to-5) package to translate a [protocol version 6 provider server](/terraform/plugin/how-terraform-works#protocol-version-6) into a [protocol version 5 provider server](/terraform/plugin/how-terraform-works#protocol-version-5).

--- a/website/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/website/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -6,31 +6,31 @@ description: >-
 
 # Translating Protocol Version 5 to 6
 
-The [`tf5to6server`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf5to6server) package enables translating a [protocol version 5](/plugin/how-terraform-works#protocol-version-5)  provider server into a [protocol version 6](/plugin/how-terraform-works#protocol-version-6)  provider server.
+The [`tf5to6server`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf5to6server) package enables translating a [protocol version 5](/terraform/plugin/how-terraform-works#protocol-version-5)  provider server into a [protocol version 6](/terraform/plugin/how-terraform-works#protocol-version-6)  provider server.
 
 Use this package to:
 
-* Migrate individual resources and data sources from [terraform-plugin-sdk/v2](/plugin/sdkv2) to [terraform-plugin-framework](/plugin/framework) over time, while using protocol version 6 features in terraform-plugin-framework.
-* Develop with [terraform-plugin-sdk/v2](/plugin/sdkv2), but require Terraform CLI 1.0 or later.
+* Migrate individual resources and data sources from [terraform-plugin-sdk/v2](/terraform/plugin/sdkv2) to [terraform-plugin-framework](/terraform/plugin/framework) over time, while using protocol version 6 features in terraform-plugin-framework.
+* Develop with [terraform-plugin-sdk/v2](/terraform/plugin/sdkv2), but require Terraform CLI 1.0 or later.
 
 ## Compatibility
 
-Protocol version 6 provider servers are compatible with Terraform CLI 1.0 and later. Terraform CLI 1.1.5 and later is required to upgrade [terraform-plugin-sdk/v2](/plugin/sdkv2).
+Protocol version 6 provider servers are compatible with Terraform CLI 1.0 and later. Terraform CLI 1.1.5 and later is required to upgrade [terraform-plugin-sdk/v2](/terraform/plugin/sdkv2).
 
 The following provider server implementations are supported:
 
-* [terraform-plugin-sdk/v2](/plugin/sdkv2): A higher-level SDK that makes Terraform provider development easier by abstracting implementation details.
+* [terraform-plugin-sdk/v2](/terraform/plugin/sdkv2): A higher-level SDK that makes Terraform provider development easier by abstracting implementation details.
 * [terraform-plugin-go tf5server](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server): A lower-level SDK to develop Terraform providers for more advanced use cases.
 
 ## Requirements
 
 Upgrading provider servers from protocol version 5 to protocol version 6 has no provider code requirements.
 
-If publishing to the [Terraform Registry](/registry), set `metadata.protocol_versions` to `["6.0"]` in the [Terraform Registry manifest file](/registry/providers/publishing#terraform-registry-manifest-file).
+If publishing to the [Terraform Registry](/terraform/registry), set `metadata.protocol_versions` to `["6.0"]` in the [Terraform Registry manifest file](/terraform/registry/providers/publishing#terraform-registry-manifest-file).
 
 ## Code Implementation
 
-Use the [`tf5to6server.UpgradeServer()`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf5to6server#UpgradeServer) function to wrap a provider server. For most providers, this is either in the provider `main()` function of the root directory `main.go` file or where [`tf6muxserver`](/plugin/mux/combining-protocol-version-6-providers) is implemented in the codebase.
+Use the [`tf5to6server.UpgradeServer()`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf5to6server#UpgradeServer) function to wrap a provider server. For most providers, this is either in the provider `main()` function of the root directory `main.go` file or where [`tf6muxserver`](/terraform/plugin/mux/combining-protocol-version-6-providers) is implemented in the codebase.
 
 The following example upgrades a terraform-plugin-sdk/v2 provider.
 
@@ -52,7 +52,7 @@ err = tf6server.Serve(
 )
 ```
 
-The following example uses [`tf6muxserver`](/plugin/mux/combining-protocol-version-6-providers) to serve the upgraded provider while it is combined with others.
+The following example uses [`tf6muxserver`](/terraform/plugin/mux/combining-protocol-version-6-providers) to serve the upgraded provider while it is combined with others.
 
 ```go
 providers := []func() tfprotov6.ProviderServer{
@@ -67,11 +67,11 @@ providers := []func() tfprotov6.ProviderServer{
 muxServer, err := tf6muxserver.NewMuxServer(ctx, providers...)
 ```
 
-Refer to the [`tf6muxserver`](/plugin/mux/combining-protocol-version-6-providers) documentation for more details about how to serve the combined provider.
+Refer to the [`tf6muxserver`](/terraform/plugin/mux/combining-protocol-version-6-providers) documentation for more details about how to serve the combined provider.
 
 ## Testing Implementation
 
-You can test the original provider using the same [acceptance tests](/plugin/sdkv2/testing/acceptance-tests) as before. Set the [`ProtoV6ProviderFactories`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#TestCase.ProtoV6ProviderFactories) field of `TestCase` to use the acceptance testing framework available in [terraform-provider-sdk/v2/helper/resource](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource).
+You can test the original provider using the same [acceptance tests](/terraform/plugin/sdkv2/testing/acceptance-tests) as before. Set the [`ProtoV6ProviderFactories`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#TestCase.ProtoV6ProviderFactories) field of `TestCase` to use the acceptance testing framework available in [terraform-provider-sdk/v2/helper/resource](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource).
 
 The following example creates a test for a combined provider.
 
@@ -89,4 +89,4 @@ resource.Test(t, resource.TestCase{
 })
 ```
 
-Refer to the [acceptance tests](/plugin/sdkv2/testing/acceptance-tests) documentation for more details.
+Refer to the [acceptance tests](/terraform/plugin/sdkv2/testing/acceptance-tests) documentation for more details.

--- a/website/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/website/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -6,12 +6,12 @@ description: >-
 
 # Translating Protocol Version 6 to 5
 
-The [`tf6to5server`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf6to5server) package enables translating a [protocol version 6](/plugin/how-terraform-works#protocol-version-6)  provider server into a [protocol version 5](/plugin/how-terraform-works#protocol-version-5) provider server.
+The [`tf6to5server`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf6to5server) package enables translating a [protocol version 6](/terraform/plugin/how-terraform-works#protocol-version-6)  provider server into a [protocol version 5](/terraform/plugin/how-terraform-works#protocol-version-5) provider server.
 
 Use this package to:
 
-* Migrate individual resources and data sources from [terraform-plugin-sdk/v2](/plugin/sdkv2) to [terraform-plugin-framework](/plugin/framework) over time, while maintaining Terraform CLI 0.12 and later compatibility.
-* Develop with [terraform-plugin-framework](/plugin/framework), but support Terraform CLI 0.12 and later.
+* Migrate individual resources and data sources from [terraform-plugin-sdk/v2](/terraform/plugin/sdkv2) to [terraform-plugin-framework](/terraform/plugin/framework) over time, while maintaining Terraform CLI 0.12 and later compatibility.
+* Develop with [terraform-plugin-framework](/terraform/plugin/framework), but support Terraform CLI 0.12 and later.
 
 ## Compatibility
 
@@ -19,18 +19,18 @@ Protocol version 5 provider servers are compatible with Terraform CLI 0.12 and l
 
 The following provider server implementations are supported:
 
-* [terraform-plugin-framework](/plugin/framework): A higher-level SDK that makes Terraform provider development easier by abstracting implementation details.
+* [terraform-plugin-framework](/terraform/plugin/framework): A higher-level SDK that makes Terraform provider development easier by abstracting implementation details.
 * [terraform-plugin-go tf6server](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server): A lower-level SDK to develop Terraform providers for more advanced use cases.
 
 ## Requirements
 
-Downgrading provider servers from protocol version 6 to protocol version 5 will return an error if there are protocol version 6 features that are in use that are not available in protocol version 5. Refer to the [protocol version 6](/plugin/how-terraform-works#protocol-version-6) documentation for more information.
+Downgrading provider servers from protocol version 6 to protocol version 5 will return an error if there are protocol version 6 features that are in use that are not available in protocol version 5. Refer to the [protocol version 6](/terraform/plugin/how-terraform-works#protocol-version-6) documentation for more information.
 
-If publishing to the [Terraform Registry](/registry), set `metadata.protocol_versions` to `["5.0"]` in the [Terraform Registry manifest file](/registry/providers/publishing#terraform-registry-manifest-file).
+If publishing to the [Terraform Registry](/terraform/registry), set `metadata.protocol_versions` to `["5.0"]` in the [Terraform Registry manifest file](/terraform/registry/providers/publishing#terraform-registry-manifest-file).
 
 ## Code Implementation
 
-Use the [`tf6to5server.DowngradeServer()`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf6to5server#DowngradeServer) function to wrap a provider server. For most providers, this is in the provider `main()` function of the root directory `main.go` file or where [`tf5muxserver`](/plugin/mux/combining-protocol-version-5-providers) is implemented in the codebase, if applicable.
+Use the [`tf6to5server.DowngradeServer()`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf6to5server#DowngradeServer) function to wrap a provider server. For most providers, this is in the provider `main()` function of the root directory `main.go` file or where [`tf5muxserver`](/terraform/plugin/mux/combining-protocol-version-5-providers) is implemented in the codebase, if applicable.
 
 The following example downgrades a `terraform-plugin-framework` provider.
 
@@ -52,7 +52,7 @@ err = tf5server.Serve(
 )
 ```
 
-The following example uses [`tf5muxserver`](/plugin/mux/combining-protocol-version-5-providers) to serve the downgraded provider while it is combined with other providers.
+The following example uses [`tf5muxserver`](/terraform/plugin/mux/combining-protocol-version-5-providers) to serve the downgraded provider while it is combined with other providers.
 
 ```go
 providers := []func() tfprotov5.ProviderServer{
@@ -67,11 +67,11 @@ providers := []func() tfprotov5.ProviderServer{
 muxServer, err := tf5muxserver.NewMuxServer(ctx, providers...)
 ```
 
-Refer to the [`tf5muxserver`](/plugin/mux/combining-protocol-version-5-providers) documentation for more details about how to serve the combined provider.
+Refer to the [`tf5muxserver`](/terraform/plugin/mux/combining-protocol-version-5-providers) documentation for more details about how to serve the combined provider.
 
 ## Testing Implementation
 
-You can test the original provider using the same [acceptance tests](/plugin/sdkv2/testing/acceptance-tests) as before. Set the [`ProtoV5ProviderFactories`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#TestCase.ProtoV5ProviderFactories) field of `TestCase` to use the acceptance testing framework available in [terraform-provider-sdk/v2/helper/resource](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource).
+You can test the original provider using the same [acceptance tests](/terraform/plugin/sdkv2/testing/acceptance-tests) as before. Set the [`ProtoV5ProviderFactories`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#TestCase.ProtoV5ProviderFactories) field of `TestCase` to use the acceptance testing framework available in [terraform-provider-sdk/v2/helper/resource](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource).
 
 The following example creates a test case for a downgraded provider.
 
@@ -89,4 +89,4 @@ resource.Test(t, resource.TestCase{
 })
 ```
 
-Refer to the [acceptance tests](/plugin/sdkv2/testing/acceptance-tests) documentation for more details.
+Refer to the [acceptance tests](/terraform/plugin/sdkv2/testing/acceptance-tests) documentation for more details.


### PR DESCRIPTION
## What

- Migrates the formats of links in Markdown content as part of the [Docs Content Link Rewrites project](https://docs.google.com/document/d/1WaSyvoVPS-YCNiSPX0ynGpvc1gySEcpbrRoQVhimQCA/edit)

## Reviewing

- [ ] The updated links should point to the same pages
- [ ] The lists of "unrewriteable" links below should not contain any links we expect to be rewritten

These are all the links that were determined to be "unrewriteable" (AKA no rewrite needed to be applied based on the rewrite script's logic):

<details>
<summary>🌟 Expand for lists of links by file name</summary>

```JSON
{
  "website/docs/plugin/mux/combining-protocol-version-5-providers.mdx": [
    "https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf5muxserver",
    "https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server",
    "https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf5muxserver#NewMuxServer",
    "#testing-implementation",
    "https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server#WithManagedDebug",
    "https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#TestCase.ProtoV5ProviderFactories",
    "https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
  ],
  "website/docs/plugin/mux/combining-protocol-version-6-providers.mdx": [
    "https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf6muxserver",
    "https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server",
    "https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf6muxserver#NewMuxServer",
    "#testing-implementation",
    "https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server#WithManagedDebug",
    "https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#TestCase.ProtoV6ProviderFactories",
    "https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
  ],
  "website/docs/plugin/mux/index.mdx": [
    "https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux",
    "https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go"
  ],
  "website/docs/plugin/mux/translating-protocol-version-5-to-6.mdx": [
    "https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf5to6server",
    "https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server",
    "https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf5to6server#UpgradeServer",
    "https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server",
    "https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#TestCase.ProtoV6ProviderFactories",
    "https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
  ],
  "website/docs/plugin/mux/translating-protocol-version-6-to-5.mdx": [
    "https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf6to5server",
    "https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server",
    "https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf6to5server#DowngradeServer",
    "https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server",
    "https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#TestCase.ProtoV5ProviderFactories",
    "https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
  ]
}
```

</details>

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203715368770953
  - https://app.asana.com/0/0/1203534392784697