### PR TITLE
tf5muxserver+tf6muxserver: Ensure mux server errors in `GetProviderSchema` response set error severity in diagnostics

### DIFF
--- a/.changes/unreleased/BUG FIXES-20230421-133145.yaml
+++ b/.changes/unreleased/BUG FIXES-20230421-133145.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'tf5muxserver+tf6muxserver: Ensure provider acceptance testing can properly
+  detect mux server errors in `GetProviderSchema` response'
+time: 2023-04-21T13:31:45.31123-04:00
+custom:
+  Issue: "152"

--- a/tf5muxserver/mux_server_GetProviderSchema.go
+++ b/tf5muxserver/mux_server_GetProviderSchema.go
@@ -33,7 +33,8 @@ func (s muxServer) GetProviderSchema(ctx context.Context, req *tfprotov5.GetProv
 
 	for _, diff := range s.serverProviderSchemaDifferences {
 		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
-			Summary: "Invalid Provider Server Combination",
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Invalid Provider Server Combination",
 			Detail: "The combined provider has differing provider schema implementations across providers. " +
 				"Provider schemas must be identical across providers. " +
 				"This is always an issue in the provider implementation and should be reported to the provider developers.\n\n" +
@@ -43,7 +44,8 @@ func (s muxServer) GetProviderSchema(ctx context.Context, req *tfprotov5.GetProv
 
 	for _, diff := range s.serverProviderMetaSchemaDifferences {
 		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
-			Summary: "Invalid Provider Server Combination",
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Invalid Provider Server Combination",
 			Detail: "The combined provider has differing provider meta schema implementations across providers. " +
 				"Provider meta schemas must be identical across providers. " +
 				"This is always an issue in the provider implementation and should be reported to the provider developers.\n\n" +
@@ -53,7 +55,8 @@ func (s muxServer) GetProviderSchema(ctx context.Context, req *tfprotov5.GetProv
 
 	for _, dataSourceType := range s.serverDataSourceSchemaDuplicates {
 		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
-			Summary: "Invalid Provider Server Combination",
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Invalid Provider Server Combination",
 			Detail: "The combined provider has multiple implementations of the same data source type across providers. " +
 				"Data source types must be implemented by only one provider. " +
 				"This is always an issue in the provider implementation and should be reported to the provider developers.\n\n" +
@@ -63,7 +66,8 @@ func (s muxServer) GetProviderSchema(ctx context.Context, req *tfprotov5.GetProv
 
 	for _, resourceType := range s.serverResourceSchemaDuplicates {
 		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
-			Summary: "Invalid Provider Server Combination",
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Invalid Provider Server Combination",
 			Detail: "The combined provider has multiple implementations of the same resource type across providers. " +
 				"Resource types must be implemented by only one provider. " +
 				"This is always an issue in the provider implementation and should be reported to the provider developers.\n\n" +

--- a/tf5muxserver/mux_server_GetProviderSchema_test.go
+++ b/tf5muxserver/mux_server_GetProviderSchema_test.go
@@ -439,7 +439,8 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			},
 			expectedDiagnostics: []*tfprotov5.Diagnostic{
 				{
-					Summary: "Invalid Provider Server Combination",
+					Severity: tfprotov5.DiagnosticSeverityError,
+					Summary:  "Invalid Provider Server Combination",
 					Detail: "The combined provider has multiple implementations of the same data source type across providers. " +
 						"Data source types must be implemented by only one provider. " +
 						"This is always an issue in the provider implementation and should be reported to the provider developers.\n\n" +
@@ -467,7 +468,8 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			expectedDataSourceSchemas: map[string]*tfprotov5.Schema{},
 			expectedDiagnostics: []*tfprotov5.Diagnostic{
 				{
-					Summary: "Invalid Provider Server Combination",
+					Severity: tfprotov5.DiagnosticSeverityError,
+					Summary:  "Invalid Provider Server Combination",
 					Detail: "The combined provider has multiple implementations of the same resource type across providers. " +
 						"Resource types must be implemented by only one provider. " +
 						"This is always an issue in the provider implementation and should be reported to the provider developers.\n\n" +
@@ -513,7 +515,8 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			expectedDataSourceSchemas: map[string]*tfprotov5.Schema{},
 			expectedDiagnostics: []*tfprotov5.Diagnostic{
 				{
-					Summary: "Invalid Provider Server Combination",
+					Severity: tfprotov5.DiagnosticSeverityError,
+					Summary:  "Invalid Provider Server Combination",
 					Detail: "The combined provider has differing provider schema implementations across providers. " +
 						"Provider schemas must be identical across providers. " +
 						"This is always an issue in the provider implementation and should be reported to the provider developers.\n\n" +
@@ -591,7 +594,8 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			expectedDataSourceSchemas: map[string]*tfprotov5.Schema{},
 			expectedDiagnostics: []*tfprotov5.Diagnostic{
 				{
-					Summary: "Invalid Provider Server Combination",
+					Severity: tfprotov5.DiagnosticSeverityError,
+					Summary:  "Invalid Provider Server Combination",
 					Detail: "The combined provider has differing provider meta schema implementations across providers. " +
 						"Provider meta schemas must be identical across providers. " +
 						"This is always an issue in the provider implementation and should be reported to the provider developers.\n\n" +

--- a/tf6muxserver/mux_server_GetProviderSchema.go
+++ b/tf6muxserver/mux_server_GetProviderSchema.go
@@ -33,7 +33,8 @@ func (s muxServer) GetProviderSchema(ctx context.Context, req *tfprotov6.GetProv
 
 	for _, diff := range s.serverProviderSchemaDifferences {
 		resp.Diagnostics = append(resp.Diagnostics, &tfprotov6.Diagnostic{
-			Summary: "Invalid Provider Server Combination",
+			Severity: tfprotov6.DiagnosticSeverityError,
+			Summary:  "Invalid Provider Server Combination",
 			Detail: "The combined provider has differing provider schema implementations across providers. " +
 				"Provider schemas must be identical across providers. " +
 				"This is always an issue in the provider implementation and should be reported to the provider developers.\n\n" +
@@ -43,7 +44,8 @@ func (s muxServer) GetProviderSchema(ctx context.Context, req *tfprotov6.GetProv
 
 	for _, diff := range s.serverProviderMetaSchemaDifferences {
 		resp.Diagnostics = append(resp.Diagnostics, &tfprotov6.Diagnostic{
-			Summary: "Invalid Provider Server Combination",
+			Severity: tfprotov6.DiagnosticSeverityError,
+			Summary:  "Invalid Provider Server Combination",
 			Detail: "The combined provider has differing provider meta schema implementations across providers. " +
 				"Provider meta schemas must be identical across providers. " +
 				"This is always an issue in the provider implementation and should be reported to the provider developers.\n\n" +
@@ -53,7 +55,8 @@ func (s muxServer) GetProviderSchema(ctx context.Context, req *tfprotov6.GetProv
 
 	for _, dataSourceType := range s.serverDataSourceSchemaDuplicates {
 		resp.Diagnostics = append(resp.Diagnostics, &tfprotov6.Diagnostic{
-			Summary: "Invalid Provider Server Combination",
+			Severity: tfprotov6.DiagnosticSeverityError,
+			Summary:  "Invalid Provider Server Combination",
 			Detail: "The combined provider has multiple implementations of the same data source type across providers. " +
 				"Data source types must be implemented by only one provider. " +
 				"This is always an issue in the provider implementation and should be reported to the provider developers.\n\n" +
@@ -63,7 +66,8 @@ func (s muxServer) GetProviderSchema(ctx context.Context, req *tfprotov6.GetProv
 
 	for _, resourceType := range s.serverResourceSchemaDuplicates {
 		resp.Diagnostics = append(resp.Diagnostics, &tfprotov6.Diagnostic{
-			Summary: "Invalid Provider Server Combination",
+			Severity: tfprotov6.DiagnosticSeverityError,
+			Summary:  "Invalid Provider Server Combination",
 			Detail: "The combined provider has multiple implementations of the same resource type across providers. " +
 				"Resource types must be implemented by only one provider. " +
 				"This is always an issue in the provider implementation and should be reported to the provider developers.\n\n" +

--- a/tf6muxserver/mux_server_GetProviderSchema_test.go
+++ b/tf6muxserver/mux_server_GetProviderSchema_test.go
@@ -439,7 +439,8 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			},
 			expectedDiagnostics: []*tfprotov6.Diagnostic{
 				{
-					Summary: "Invalid Provider Server Combination",
+					Severity: tfprotov6.DiagnosticSeverityError,
+					Summary:  "Invalid Provider Server Combination",
 					Detail: "The combined provider has multiple implementations of the same data source type across providers. " +
 						"Data source types must be implemented by only one provider. " +
 						"This is always an issue in the provider implementation and should be reported to the provider developers.\n\n" +
@@ -467,7 +468,8 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			expectedDataSourceSchemas: map[string]*tfprotov6.Schema{},
 			expectedDiagnostics: []*tfprotov6.Diagnostic{
 				{
-					Summary: "Invalid Provider Server Combination",
+					Severity: tfprotov6.DiagnosticSeverityError,
+					Summary:  "Invalid Provider Server Combination",
 					Detail: "The combined provider has multiple implementations of the same resource type across providers. " +
 						"Resource types must be implemented by only one provider. " +
 						"This is always an issue in the provider implementation and should be reported to the provider developers.\n\n" +
@@ -513,7 +515,8 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			expectedDataSourceSchemas: map[string]*tfprotov6.Schema{},
 			expectedDiagnostics: []*tfprotov6.Diagnostic{
 				{
-					Summary: "Invalid Provider Server Combination",
+					Severity: tfprotov6.DiagnosticSeverityError,
+					Summary:  "Invalid Provider Server Combination",
 					Detail: "The combined provider has differing provider schema implementations across providers. " +
 						"Provider schemas must be identical across providers. " +
 						"This is always an issue in the provider implementation and should be reported to the provider developers.\n\n" +
@@ -591,7 +594,8 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			expectedDataSourceSchemas: map[string]*tfprotov6.Schema{},
 			expectedDiagnostics: []*tfprotov6.Diagnostic{
 				{
-					Summary: "Invalid Provider Server Combination",
+					Severity: tfprotov6.DiagnosticSeverityError,
+					Summary:  "Invalid Provider Server Combination",
 					Detail: "The combined provider has differing provider meta schema implementations across providers. " +
 						"Provider meta schemas must be identical across providers. " +
 						"This is always an issue in the provider implementation and should be reported to the provider developers.\n\n" +


### PR DESCRIPTION
Closes #152