### PR TITLE
docs: Remove errant sdk/v2 specifics

### DIFF
--- a/website/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/website/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -103,7 +103,7 @@ func main() {
 
 ## Testing Implementation
 
-You can test individual providers using the same [acceptance tests](/terraform/plugin/sdkv2/testing/acceptance-tests) as before. Set the [`ProtoV5ProviderFactories` field of `TestCase`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#TestCase.ProtoV5ProviderFactories) to use the acceptance testing framework available in [terraform-provider-sdk/v2/helper/resource](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource). 
+You can test individual providers using the same [acceptance tests](/terraform/plugin/testing/acceptance-tests) as before. Set the `ProtoV5ProviderFactories` field of `TestCase` with an instance of the mux server, instead of declaring the provider with other `TestCase` fields such as `ProviderFactories`.
 
 The following example uses the acceptance testing framework to create a test for two providers.
 
@@ -136,4 +136,4 @@ resource.Test(t, resource.TestCase{
 })
 ```
 
-Refer to the [acceptance tests](/terraform/plugin/sdkv2/testing/acceptance-tests) documentation for more details.
+Refer to the [acceptance tests](/terraform/plugin/testing/acceptance-tests) documentation for more details.

--- a/website/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/website/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -97,7 +97,7 @@ func main() {
 
 ## Testing Implementation
 
-You can test individual providers using the same [acceptance tests](/terraform/plugin/sdkv2/testing/acceptance-tests) as before. Set the [`ProtoV6ProviderFactories` field of `TestCase`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#TestCase.ProtoV6ProviderFactories) to use the acceptance testing framework available in [terraform-provider-sdk/v2/helper/resource](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource).
+You can test individual providers using the same [acceptance tests](/terraform/plugin/testing/acceptance-tests) as before. Set the `ProtoV6ProviderFactories` field of `TestCase` with an instance of the mux server, instead of declaring the provider with other `TestCase` fields such as `ProviderFactories`.
 
 The following example uses the acceptance testing framework to create a test for two providers.
 
@@ -125,4 +125,4 @@ resource.Test(t, resource.TestCase{
 })
 ```
 
-Refer to the [acceptance tests](/terraform/plugin/sdkv2/testing/acceptance-tests) documentation for more details.
+Refer to the [acceptance tests](/terraform/plugin/testing/acceptance-tests) documentation for more details.

--- a/website/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/website/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -71,7 +71,7 @@ Refer to the [`tf6muxserver`](/terraform/plugin/mux/combining-protocol-version-6
 
 ## Testing Implementation
 
-You can test the original provider using the same [acceptance tests](/terraform/plugin/sdkv2/testing/acceptance-tests) as before. Set the [`ProtoV6ProviderFactories`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#TestCase.ProtoV6ProviderFactories) field of `TestCase` to use the acceptance testing framework available in [terraform-provider-sdk/v2/helper/resource](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource).
+You can test the original provider using the same [acceptance tests](/terraform/plugin/testing/acceptance-tests) as before. Set the `ProtoV6ProviderFactories` field of `TestCase` with an instance of the upgraded server, instead of declaring the provider with other `TestCase` fields such as `ProviderFactories`.
 
 The following example creates a test for a combined provider.
 
@@ -89,4 +89,4 @@ resource.Test(t, resource.TestCase{
 })
 ```
 
-Refer to the [acceptance tests](/terraform/plugin/sdkv2/testing/acceptance-tests) documentation for more details.
+Refer to the [acceptance tests](/terraform/plugin/testing/acceptance-tests) documentation for more details.

--- a/website/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/website/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -71,7 +71,7 @@ Refer to the [`tf5muxserver`](/terraform/plugin/mux/combining-protocol-version-5
 
 ## Testing Implementation
 
-You can test the original provider using the same [acceptance tests](/terraform/plugin/sdkv2/testing/acceptance-tests) as before. Set the [`ProtoV5ProviderFactories`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#TestCase.ProtoV5ProviderFactories) field of `TestCase` to use the acceptance testing framework available in [terraform-provider-sdk/v2/helper/resource](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource).
+You can test the original provider using the same [acceptance tests](/terraform/plugin/testing/acceptance-tests) as before. Set the `ProtoV5ProviderFactories` field of `TestCase` with an instance of the upgraded server, instead of declaring the provider with other `TestCase` fields such as `ProviderFactories`.
 
 The following example creates a test case for a downgraded provider.
 


### PR DESCRIPTION
Reference: https://discuss.hashicorp.com/t/terraform-framework-migration-testing/55744/2

Since this documentation was introduced, the terraform-plugin-testing Go module and its associated https://developer.hashicorp/terraform/plugin/testing documentation were released. The prior documentation made it sound like sdk/v2-based acceptance testing was required while either testing setup can be used.