### PR TITLE
DRY-up usage of GetProviderSchemaResponse

### DIFF
--- a/internal/tf5testserver/tf5testserver.go
+++ b/internal/tf5testserver/tf5testserver.go
@@ -66,7 +66,12 @@ func (s *TestServer) ConfigureProvider(_ context.Context, _ *tfprotov5.Configure
 
 func (s *TestServer) GetProviderSchema(_ context.Context, _ *tfprotov5.GetProviderSchemaRequest) (*tfprotov5.GetProviderSchemaResponse, error) {
 	s.GetProviderSchemaCalled = true
-	return s.GetProviderSchemaResponse, nil
+
+	if s.GetProviderSchemaResponse != nil {
+		return s.GetProviderSchemaResponse, nil
+	}
+
+	return &tfprotov5.GetProviderSchemaResponse{}, nil
 }
 
 func (s *TestServer) ImportResourceState(_ context.Context, req *tfprotov5.ImportResourceStateRequest) (*tfprotov5.ImportResourceStateResponse, error) {

--- a/internal/tf6testserver/tf6testserver.go
+++ b/internal/tf6testserver/tf6testserver.go
@@ -66,7 +66,12 @@ func (s *TestServer) ConfigureProvider(_ context.Context, _ *tfprotov6.Configure
 
 func (s *TestServer) GetProviderSchema(_ context.Context, _ *tfprotov6.GetProviderSchemaRequest) (*tfprotov6.GetProviderSchemaResponse, error) {
 	s.GetProviderSchemaCalled = true
-	return s.GetProviderSchemaResponse, nil
+
+	if s.GetProviderSchemaResponse != nil {
+		return s.GetProviderSchemaResponse, nil
+	}
+
+	return &tfprotov6.GetProviderSchemaResponse{}, nil
 }
 
 func (s *TestServer) ImportResourceState(_ context.Context, req *tfprotov6.ImportResourceStateRequest) (*tfprotov6.ImportResourceStateResponse, error) {

--- a/tf5muxserver/mux_server_ConfigureProvider_test.go
+++ b/tf5muxserver/mux_server_ConfigureProvider_test.go
@@ -19,11 +19,8 @@ func TestMuxServerConfigureProvider(t *testing.T) {
 
 	ctx := context.Background()
 	testServers := [5]*tf5testserver.TestServer{
+		{},
 		{
-			GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-		},
-		{
-			GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
 			ConfigureProviderResponse: &tfprotov5.ConfigureProviderResponse{
 				Diagnostics: []*tfprotov5.Diagnostic{
 					{
@@ -34,11 +31,8 @@ func TestMuxServerConfigureProvider(t *testing.T) {
 				},
 			},
 		},
+		{},
 		{
-			GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-		},
-		{
-			GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
 			ConfigureProviderResponse: &tfprotov5.ConfigureProviderResponse{
 				Diagnostics: []*tfprotov5.Diagnostic{
 					{
@@ -50,7 +44,6 @@ func TestMuxServerConfigureProvider(t *testing.T) {
 			},
 		},
 		{
-			GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
 			ConfigureProviderResponse: &tfprotov5.ConfigureProviderResponse{
 				Diagnostics: []*tfprotov5.Diagnostic{
 					{

--- a/tf5muxserver/mux_server_GetProviderSchema_test.go
+++ b/tf5muxserver/mux_server_GetProviderSchema_test.go
@@ -707,12 +707,8 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 						},
 					},
 				}).ProviderServer,
-				(&tf5testserver.TestServer{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-				}).ProviderServer,
-				(&tf5testserver.TestServer{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-				}).ProviderServer,
+				(&tf5testserver.TestServer{}).ProviderServer,
+				(&tf5testserver.TestServer{}).ProviderServer,
 			},
 			expectedDataSourceSchemas: map[string]*tfprotov5.Schema{},
 			expectedDiagnostics: []*tfprotov5.Diagnostic{
@@ -737,9 +733,7 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 						},
 					},
 				}).ProviderServer,
-				(&tf5testserver.TestServer{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-				}).ProviderServer,
+				(&tf5testserver.TestServer{}).ProviderServer,
 				(&tf5testserver.TestServer{
 					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{
 						Diagnostics: []*tfprotov5.Diagnostic{
@@ -780,12 +774,8 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 						},
 					},
 				}).ProviderServer,
-				(&tf5testserver.TestServer{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-				}).ProviderServer,
-				(&tf5testserver.TestServer{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-				}).ProviderServer,
+				(&tf5testserver.TestServer{}).ProviderServer,
+				(&tf5testserver.TestServer{}).ProviderServer,
 			},
 			expectedDataSourceSchemas: map[string]*tfprotov5.Schema{},
 			expectedDiagnostics: []*tfprotov5.Diagnostic{
@@ -810,9 +800,7 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 						},
 					},
 				}).ProviderServer,
-				(&tf5testserver.TestServer{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-				}).ProviderServer,
+				(&tf5testserver.TestServer{}).ProviderServer,
 				(&tf5testserver.TestServer{
 					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{
 						Diagnostics: []*tfprotov5.Diagnostic{
@@ -853,9 +841,7 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 						},
 					},
 				}).ProviderServer,
-				(&tf5testserver.TestServer{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-				}).ProviderServer,
+				(&tf5testserver.TestServer{}).ProviderServer,
 				(&tf5testserver.TestServer{
 					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{
 						Diagnostics: []*tfprotov5.Diagnostic{

--- a/tf5muxserver/mux_server_PrepareProviderConfig_test.go
+++ b/tf5muxserver/mux_server_PrepareProviderConfig_test.go
@@ -71,7 +71,6 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 		"error-once": {
 			testServers: [3]*tf5testserver.TestServer{
 				{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
 					PrepareProviderConfigResponse: &tfprotov5.PrepareProviderConfigResponse{
 						Diagnostics: []*tfprotov5.Diagnostic{
 							{
@@ -82,12 +81,8 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 						},
 					},
 				},
-				{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-				},
-				{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-				},
+				{},
+				{},
 			},
 			expectedResponse: &tfprotov5.PrepareProviderConfigResponse{
 				Diagnostics: []*tfprotov5.Diagnostic{
@@ -102,7 +97,6 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 		"error-multiple": {
 			testServers: [3]*tf5testserver.TestServer{
 				{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
 					PrepareProviderConfigResponse: &tfprotov5.PrepareProviderConfigResponse{
 						Diagnostics: []*tfprotov5.Diagnostic{
 							{
@@ -113,11 +107,8 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 						},
 					},
 				},
+				{},
 				{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-				},
-				{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
 					PrepareProviderConfigResponse: &tfprotov5.PrepareProviderConfigResponse{
 						Diagnostics: []*tfprotov5.Diagnostic{
 							{
@@ -147,7 +138,6 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 		"warning-once": {
 			testServers: [3]*tf5testserver.TestServer{
 				{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
 					PrepareProviderConfigResponse: &tfprotov5.PrepareProviderConfigResponse{
 						Diagnostics: []*tfprotov5.Diagnostic{
 							{
@@ -158,12 +148,8 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 						},
 					},
 				},
-				{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-				},
-				{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-				},
+				{},
+				{},
 			},
 			expectedResponse: &tfprotov5.PrepareProviderConfigResponse{
 				Diagnostics: []*tfprotov5.Diagnostic{
@@ -178,7 +164,6 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 		"warning-multiple": {
 			testServers: [3]*tf5testserver.TestServer{
 				{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
 					PrepareProviderConfigResponse: &tfprotov5.PrepareProviderConfigResponse{
 						Diagnostics: []*tfprotov5.Diagnostic{
 							{
@@ -189,11 +174,8 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 						},
 					},
 				},
+				{},
 				{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-				},
-				{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
 					PrepareProviderConfigResponse: &tfprotov5.PrepareProviderConfigResponse{
 						Diagnostics: []*tfprotov5.Diagnostic{
 							{
@@ -223,7 +205,6 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 		"warning-then-error": {
 			testServers: [3]*tf5testserver.TestServer{
 				{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
 					PrepareProviderConfigResponse: &tfprotov5.PrepareProviderConfigResponse{
 						Diagnostics: []*tfprotov5.Diagnostic{
 							{
@@ -234,11 +215,9 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 						},
 					},
 				},
+				{},
 				{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-				},
-				{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
+
 					PrepareProviderConfigResponse: &tfprotov5.PrepareProviderConfigResponse{
 						Diagnostics: []*tfprotov5.Diagnostic{
 							{
@@ -267,15 +246,9 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 		},
 		"no-response": {
 			testServers: [3]*tf5testserver.TestServer{
-				{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-				},
-				{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-				},
-				{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-				},
+				{},
+				{},
+				{},
 			},
 		},
 		"PreparedConfig-once": {
@@ -288,12 +261,8 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 						PreparedConfig: &config,
 					},
 				},
-				{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-				},
-				{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-				},
+				{},
+				{},
 			},
 			expectedResponse: &tfprotov5.PrepareProviderConfigResponse{
 				PreparedConfig: &config,
@@ -309,9 +278,7 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 						PreparedConfig: &config,
 					},
 				},
-				{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-				},
+				{},
 				{
 					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{
 						Provider: &configSchema,
@@ -349,11 +316,8 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 						PreparedConfig: &config,
 					},
 				},
+				{},
 				{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-				},
-				{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
 					PrepareProviderConfigResponse: &tfprotov5.PrepareProviderConfigResponse{
 						Diagnostics: []*tfprotov5.Diagnostic{
 							{
@@ -386,9 +350,7 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 						PreparedConfig: &config,
 					},
 				},
-				{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-				},
+				{},
 				{
 					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{
 						Provider: &configSchema,
@@ -410,9 +372,7 @@ func TestMuxServerPrepareProviderConfig(t *testing.T) {
 						PreparedConfig: &config,
 					},
 				},
-				{
-					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-				},
+				{},
 				{
 					GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{
 						Provider: &configSchema,

--- a/tf5muxserver/mux_server_StopProvider_test.go
+++ b/tf5muxserver/mux_server_StopProvider_test.go
@@ -19,27 +19,19 @@ func TestMuxServerStopProvider(t *testing.T) {
 
 	ctx := context.Background()
 	testServers := [5]*tf5testserver.TestServer{
+		{},
 		{
-			GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-		},
-		{
-			GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
 			StopProviderResponse: &tfprotov5.StopProviderResponse{
 				Error: "error in server2",
 			},
 		},
+		{},
 		{
-			GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-		},
-		{
-			GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
 			StopProviderResponse: &tfprotov5.StopProviderResponse{
 				Error: "error in server4",
 			},
 		},
-		{
-			GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{},
-		},
+		{},
 	}
 
 	servers := []func() tfprotov5.ProviderServer{

--- a/tf6muxserver/mux_server_ConfigureProvider_test.go
+++ b/tf6muxserver/mux_server_ConfigureProvider_test.go
@@ -19,11 +19,8 @@ func TestMuxServerConfigureProvider(t *testing.T) {
 
 	ctx := context.Background()
 	testServers := [5]*tf6testserver.TestServer{
+		{},
 		{
-			GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
-		},
-		{
-			GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
 			ConfigureProviderResponse: &tfprotov6.ConfigureProviderResponse{
 				Diagnostics: []*tfprotov6.Diagnostic{
 					{
@@ -34,11 +31,8 @@ func TestMuxServerConfigureProvider(t *testing.T) {
 				},
 			},
 		},
+		{},
 		{
-			GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
-		},
-		{
-			GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
 			ConfigureProviderResponse: &tfprotov6.ConfigureProviderResponse{
 				Diagnostics: []*tfprotov6.Diagnostic{
 					{
@@ -50,7 +44,6 @@ func TestMuxServerConfigureProvider(t *testing.T) {
 			},
 		},
 		{
-			GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
 			ConfigureProviderResponse: &tfprotov6.ConfigureProviderResponse{
 				Diagnostics: []*tfprotov6.Diagnostic{
 					{

--- a/tf6muxserver/mux_server_GetProviderSchema_test.go
+++ b/tf6muxserver/mux_server_GetProviderSchema_test.go
@@ -707,12 +707,8 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 						},
 					},
 				}).ProviderServer,
-				(&tf6testserver.TestServer{
-					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
-				}).ProviderServer,
-				(&tf6testserver.TestServer{
-					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
-				}).ProviderServer,
+				(&tf6testserver.TestServer{}).ProviderServer,
+				(&tf6testserver.TestServer{}).ProviderServer,
 			},
 			expectedDataSourceSchemas: map[string]*tfprotov6.Schema{},
 			expectedDiagnostics: []*tfprotov6.Diagnostic{
@@ -737,9 +733,7 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 						},
 					},
 				}).ProviderServer,
-				(&tf6testserver.TestServer{
-					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
-				}).ProviderServer,
+				(&tf6testserver.TestServer{}).ProviderServer,
 				(&tf6testserver.TestServer{
 					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{
 						Diagnostics: []*tfprotov6.Diagnostic{
@@ -780,12 +774,8 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 						},
 					},
 				}).ProviderServer,
-				(&tf6testserver.TestServer{
-					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
-				}).ProviderServer,
-				(&tf6testserver.TestServer{
-					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
-				}).ProviderServer,
+				(&tf6testserver.TestServer{}).ProviderServer,
+				(&tf6testserver.TestServer{}).ProviderServer,
 			},
 			expectedDataSourceSchemas: map[string]*tfprotov6.Schema{},
 			expectedDiagnostics: []*tfprotov6.Diagnostic{
@@ -810,9 +800,7 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 						},
 					},
 				}).ProviderServer,
-				(&tf6testserver.TestServer{
-					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
-				}).ProviderServer,
+				(&tf6testserver.TestServer{}).ProviderServer,
 				(&tf6testserver.TestServer{
 					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{
 						Diagnostics: []*tfprotov6.Diagnostic{
@@ -853,9 +841,7 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 						},
 					},
 				}).ProviderServer,
-				(&tf6testserver.TestServer{
-					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
-				}).ProviderServer,
+				(&tf6testserver.TestServer{}).ProviderServer,
 				(&tf6testserver.TestServer{
 					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{
 						Diagnostics: []*tfprotov6.Diagnostic{

--- a/tf6muxserver/mux_server_StopProvider_test.go
+++ b/tf6muxserver/mux_server_StopProvider_test.go
@@ -19,26 +19,19 @@ func TestMuxServerStopProvider(t *testing.T) {
 
 	ctx := context.Background()
 	testServers := [5]*tf6testserver.TestServer{
+		{},
 		{
-			GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
-		}, {
-			GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
 			StopProviderResponse: &tfprotov6.StopProviderResponse{
 				Error: "error in server2",
 			},
 		},
+		{},
 		{
-			GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
-		},
-		{
-			GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
 			StopProviderResponse: &tfprotov6.StopProviderResponse{
 				Error: "error in server4",
 			},
 		},
-		{
-			GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
-		},
+		{},
 	}
 
 	servers := []func() tfprotov6.ProviderServer{

--- a/tf6muxserver/mux_server_ValidateProviderConfig_test.go
+++ b/tf6muxserver/mux_server_ValidateProviderConfig_test.go
@@ -71,7 +71,6 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 		"error-once": {
 			testServers: [3]*tf6testserver.TestServer{
 				{
-					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						Diagnostics: []*tfprotov6.Diagnostic{
 							{
@@ -82,12 +81,8 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 						},
 					},
 				},
-				{
-					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
-				},
-				{
-					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
-				},
+				{},
+				{},
 			},
 			expectedResponse: &tfprotov6.ValidateProviderConfigResponse{
 				Diagnostics: []*tfprotov6.Diagnostic{
@@ -102,7 +97,6 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 		"error-multiple": {
 			testServers: [3]*tf6testserver.TestServer{
 				{
-					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						Diagnostics: []*tfprotov6.Diagnostic{
 							{
@@ -113,11 +107,8 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 						},
 					},
 				},
+				{},
 				{
-					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
-				},
-				{
-					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						Diagnostics: []*tfprotov6.Diagnostic{
 							{
@@ -147,7 +138,6 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 		"warning-once": {
 			testServers: [3]*tf6testserver.TestServer{
 				{
-					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						Diagnostics: []*tfprotov6.Diagnostic{
 							{
@@ -158,12 +148,8 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 						},
 					},
 				},
-				{
-					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
-				},
-				{
-					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
-				},
+				{},
+				{},
 			},
 			expectedResponse: &tfprotov6.ValidateProviderConfigResponse{
 				Diagnostics: []*tfprotov6.Diagnostic{
@@ -178,7 +164,6 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 		"warning-multiple": {
 			testServers: [3]*tf6testserver.TestServer{
 				{
-					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						Diagnostics: []*tfprotov6.Diagnostic{
 							{
@@ -189,11 +174,8 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 						},
 					},
 				},
+				{},
 				{
-					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
-				},
-				{
-					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						Diagnostics: []*tfprotov6.Diagnostic{
 							{
@@ -223,7 +205,6 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 		"warning-then-error": {
 			testServers: [3]*tf6testserver.TestServer{
 				{
-					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						Diagnostics: []*tfprotov6.Diagnostic{
 							{
@@ -234,11 +215,8 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 						},
 					},
 				},
+				{},
 				{
-					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
-				},
-				{
-					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
 					ValidateProviderConfigResponse: &tfprotov6.ValidateProviderConfigResponse{
 						Diagnostics: []*tfprotov6.Diagnostic{
 							{
@@ -267,15 +245,9 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 		},
 		"no-response": {
 			testServers: [3]*tf6testserver.TestServer{
-				{
-					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
-				},
-				{
-					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
-				},
-				{
-					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
-				},
+				{},
+				{},
+				{},
 			},
 		},
 		"PreparedConfig-once": {
@@ -288,12 +260,8 @@ func TestMuxServerValidateProviderConfig(t *testing.T) {
 						PreparedConfig: &config,
 					},
 				},
-				{
-					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
-				},
-				{
-					GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{},
-				},
+				{},
+				{},
 			},
 			expectedResponse: &tfprotov6.ValidateProviderConfigResponse{
 				PreparedConfig: &config,


### PR DESCRIPTION
This PR adds the return of an empty `GetProviderSchemaResponse{}` when the `TestServer.GetProviderSchemaResponse` is nil:

```go
func (s *TestServer) GetProviderSchema(_ context.Context, _ *tfprotov5.GetProviderSchemaRequest) (*tfprotov5.GetProviderSchemaResponse, error) {
	s.GetProviderSchemaCalled = true

	if s.GetProviderSchemaResponse != nil {
		return s.GetProviderSchemaResponse, nil
	}

	return &tfprotov5.GetProviderSchemaResponse{}, nil
}
```

Equivalent code changes have been made in both _tf5testserver.go_ and _tf6testserver.go_.

This allows the code to be DRY-ed up by removing the need to define an empty `GetProviderSchemaResponse` in all places in which `TestServer.GetProviderSchema()` is called and an empty `GetProviderSchemaResponse` is required.