### PR TITLE
deps: Ignore google.golang.org/grpc direct updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,9 @@ version: 2
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
+    ignore:
+      # grpc should only be updated via terraform-plugin-go
+      - dependency-name: "google.golang.org/grpc"
     schedule:
       interval: "daily"
   - package-ecosystem: "gomod"


### PR DESCRIPTION
This Go module should only be upgraded via terraform-plugin-go upgrades of the dependency.

Similar to https://github.com/hashicorp/terraform-plugin-go/blob/61e2b51627723cd1913a8b01b8cc730e99cd30d1/.github/dependabot.yml#L5-L7