### PR TITLE
all: Initial MoveResourceState implementations

### DIFF
--- a/.changes/unreleased/FEATURES-20240126-143840.yaml
+++ b/.changes/unreleased/FEATURES-20240126-143840.yaml
@@ -1,0 +1,5 @@
+kind: FEATURES
+body: 'all: Upgrade protocol versions to support the `MoveResourceState` RPC'
+time: 2024-01-26T14:38:40.092759-05:00
+custom:
+  Issue: "9999"

--- a/.changes/unreleased/FEATURES-20240126-143840.yaml
+++ b/.changes/unreleased/FEATURES-20240126-143840.yaml
@@ -2,4 +2,4 @@ kind: FEATURES
 body: 'all: Upgrade protocol versions to support the `MoveResourceState` RPC'
 time: 2024-01-26T14:38:40.092759-05:00
 custom:
-  Issue: "9999"
+  Issue: "220"

--- a/internal/tf5testserver/tf5testserver.go
+++ b/internal/tf5testserver/tf5testserver.go
@@ -32,6 +32,8 @@ type TestServer struct {
 
 	ImportResourceStateCalled map[string]bool
 
+	MoveResourceStateCalled map[string]bool
+
 	PlanResourceChangeCalled map[string]bool
 
 	PrepareProviderConfigCalled   bool
@@ -123,6 +125,15 @@ func (s *TestServer) ImportResourceState(_ context.Context, req *tfprotov5.Impor
 	}
 
 	s.ImportResourceStateCalled[req.TypeName] = true
+	return nil, nil
+}
+
+func (s *TestServer) MoveResourceState(_ context.Context, req *tfprotov5.MoveResourceStateRequest) (*tfprotov5.MoveResourceStateResponse, error) {
+	if s.MoveResourceStateCalled == nil {
+		s.MoveResourceStateCalled = make(map[string]bool)
+	}
+
+	s.MoveResourceStateCalled[req.TargetTypeName] = true
 	return nil, nil
 }
 

--- a/internal/tf6testserver/tf6testserver.go
+++ b/internal/tf6testserver/tf6testserver.go
@@ -32,6 +32,8 @@ type TestServer struct {
 
 	ImportResourceStateCalled map[string]bool
 
+	MoveResourceStateCalled map[string]bool
+
 	PlanResourceChangeCalled map[string]bool
 
 	ReadDataSourceCalled map[string]bool
@@ -123,6 +125,15 @@ func (s *TestServer) ImportResourceState(_ context.Context, req *tfprotov6.Impor
 	}
 
 	s.ImportResourceStateCalled[req.TypeName] = true
+	return nil, nil
+}
+
+func (s *TestServer) MoveResourceState(_ context.Context, req *tfprotov6.MoveResourceStateRequest) (*tfprotov6.MoveResourceStateResponse, error) {
+	if s.MoveResourceStateCalled == nil {
+		s.MoveResourceStateCalled = make(map[string]bool)
+	}
+
+	s.MoveResourceStateCalled[req.TargetTypeName] = true
 	return nil, nil
 }
 

--- a/internal/tfprotov5tov6/tfprotov5tov6.go
+++ b/internal/tfprotov5tov6/tfprotov5tov6.go
@@ -327,6 +327,33 @@ func ImportedResources(in []*tfprotov5.ImportedResource) []*tfprotov6.ImportedRe
 	return res
 }
 
+func MoveResourceStateRequest(in *tfprotov5.MoveResourceStateRequest) *tfprotov6.MoveResourceStateRequest {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.MoveResourceStateRequest{
+		SourcePrivate:         in.SourcePrivate,
+		SourceProviderAddress: in.SourceProviderAddress,
+		SourceSchemaVersion:   in.SourceSchemaVersion,
+		SourceState:           RawState(in.SourceState),
+		SourceTypeName:        in.SourceTypeName,
+		TargetTypeName:        in.TargetTypeName,
+	}
+}
+
+func MoveResourceStateResponse(in *tfprotov5.MoveResourceStateResponse) *tfprotov6.MoveResourceStateResponse {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov6.MoveResourceStateResponse{
+		Diagnostics:   Diagnostics(in.Diagnostics),
+		TargetPrivate: in.TargetPrivate,
+		TargetState:   DynamicValue(in.TargetState),
+	}
+}
+
 func PlanResourceChangeRequest(in *tfprotov5.PlanResourceChangeRequest) *tfprotov6.PlanResourceChangeRequest {
 	if in == nil {
 		return nil

--- a/internal/tfprotov5tov6/tfprotov5tov6_test.go
+++ b/internal/tfprotov5tov6/tfprotov5tov6_test.go
@@ -1030,6 +1030,96 @@ func TestImportedResources(t *testing.T) {
 	}
 }
 
+func TestMoveResourceStateRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.MoveResourceStateRequest
+		expected *tfprotov6.MoveResourceStateRequest
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.MoveResourceStateRequest{
+				SourcePrivate:         testBytes,
+				SourceProviderAddress: "example.com/namespace/test",
+				SourceSchemaVersion:   1,
+				SourceState: &tfprotov5.RawState{
+					JSON: testBytes,
+				},
+				SourceTypeName: "test_source",
+				TargetTypeName: "test_target",
+			},
+			expected: &tfprotov6.MoveResourceStateRequest{
+				SourcePrivate:         testBytes,
+				SourceProviderAddress: "example.com/namespace/test",
+				SourceSchemaVersion:   1,
+				SourceState: &tfprotov6.RawState{
+					JSON: testBytes,
+				},
+				SourceTypeName: "test_source",
+				TargetTypeName: "test_target",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.MoveResourceStateRequest(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestMoveResourceStateResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov5.MoveResourceStateResponse
+		expected *tfprotov6.MoveResourceStateResponse
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov5.MoveResourceStateResponse{
+				Diagnostics:   testTfprotov5Diagnostics,
+				TargetPrivate: testBytes,
+				TargetState:   &testTfprotov5DynamicValue,
+			},
+			expected: &tfprotov6.MoveResourceStateResponse{
+				Diagnostics:   testTfprotov6Diagnostics,
+				TargetState:   &testTfprotov6DynamicValue,
+				TargetPrivate: testBytes,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov5tov6.MoveResourceStateResponse(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
 func TestPlanResourceChangeRequest(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tfprotov6tov5/tfprotov6tov5.go
+++ b/internal/tfprotov6tov5/tfprotov6tov5.go
@@ -355,6 +355,33 @@ func ImportedResources(in []*tfprotov6.ImportedResource) []*tfprotov5.ImportedRe
 	return res
 }
 
+func MoveResourceStateRequest(in *tfprotov6.MoveResourceStateRequest) *tfprotov5.MoveResourceStateRequest {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov5.MoveResourceStateRequest{
+		SourcePrivate:         in.SourcePrivate,
+		SourceProviderAddress: in.SourceProviderAddress,
+		SourceSchemaVersion:   in.SourceSchemaVersion,
+		SourceState:           RawState(in.SourceState),
+		SourceTypeName:        in.SourceTypeName,
+		TargetTypeName:        in.TargetTypeName,
+	}
+}
+
+func MoveResourceStateResponse(in *tfprotov6.MoveResourceStateResponse) *tfprotov5.MoveResourceStateResponse {
+	if in == nil {
+		return nil
+	}
+
+	return &tfprotov5.MoveResourceStateResponse{
+		Diagnostics:   Diagnostics(in.Diagnostics),
+		TargetPrivate: in.TargetPrivate,
+		TargetState:   DynamicValue(in.TargetState),
+	}
+}
+
 func PlanResourceChangeRequest(in *tfprotov6.PlanResourceChangeRequest) *tfprotov5.PlanResourceChangeRequest {
 	if in == nil {
 		return nil

--- a/internal/tfprotov6tov5/tfprotov6tov5_test.go
+++ b/internal/tfprotov6tov5/tfprotov6tov5_test.go
@@ -1145,6 +1145,96 @@ func TestImportedResources(t *testing.T) {
 	}
 }
 
+func TestMoveResourceStateRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov6.MoveResourceStateRequest
+		expected *tfprotov5.MoveResourceStateRequest
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.MoveResourceStateRequest{
+				SourcePrivate:         testBytes,
+				SourceProviderAddress: "example.com/namespace/test",
+				SourceSchemaVersion:   1,
+				SourceState: &tfprotov6.RawState{
+					JSON: testBytes,
+				},
+				SourceTypeName: "test_source",
+				TargetTypeName: "test_target",
+			},
+			expected: &tfprotov5.MoveResourceStateRequest{
+				SourcePrivate:         testBytes,
+				SourceProviderAddress: "example.com/namespace/test",
+				SourceSchemaVersion:   1,
+				SourceState: &tfprotov5.RawState{
+					JSON: testBytes,
+				},
+				SourceTypeName: "test_source",
+				TargetTypeName: "test_target",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.MoveResourceStateRequest(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestMoveResourceStateResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in       *tfprotov6.MoveResourceStateResponse
+		expected *tfprotov5.MoveResourceStateResponse
+	}{
+		"nil": {
+			in:       nil,
+			expected: nil,
+		},
+		"all-valid-fields": {
+			in: &tfprotov6.MoveResourceStateResponse{
+				Diagnostics:   testTfprotov6Diagnostics,
+				TargetPrivate: testBytes,
+				TargetState:   &testTfprotov6DynamicValue,
+			},
+			expected: &tfprotov5.MoveResourceStateResponse{
+				Diagnostics:   testTfprotov5Diagnostics,
+				TargetState:   &testTfprotov5DynamicValue,
+				TargetPrivate: testBytes,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfprotov6tov5.MoveResourceStateResponse(testCase.in)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
 func TestPlanResourceChangeRequest(t *testing.T) {
 	t.Parallel()
 

--- a/tf5muxserver/mux_server.go
+++ b/tf5muxserver/mux_server.go
@@ -15,6 +15,15 @@ import (
 
 var _ tfprotov5.ProviderServer = &muxServer{}
 
+// Temporarily verify that v5tov6Server implements new RPCs correctly.
+// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
+// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/219
+var (
+	_ tfprotov5.FunctionServer = &muxServer{}
+	//nolint:staticcheck // Intentional verification of interface implementation.
+	_ tfprotov5.ResourceServerWithMoveResourceState = &muxServer{}
+)
+
 // muxServer is a gRPC server implementation that stands in front of other
 // gRPC servers, routing requests to them as if they were a single server. It
 // should always be instantiated by calling NewMuxServer().

--- a/tf5muxserver/mux_server_GetMetadata_test.go
+++ b/tf5muxserver/mux_server_GetMetadata_test.go
@@ -110,6 +110,7 @@ func TestMuxServerGetMetadata(t *testing.T) {
 			},
 			expectedServerCapabilities: &tfprotov5.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -153,6 +154,7 @@ func TestMuxServerGetMetadata(t *testing.T) {
 			expectedResources: []tfprotov5.ResourceMetadata{},
 			expectedServerCapabilities: &tfprotov5.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -196,6 +198,7 @@ func TestMuxServerGetMetadata(t *testing.T) {
 			expectedResources: []tfprotov5.ResourceMetadata{},
 			expectedServerCapabilities: &tfprotov5.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -239,6 +242,7 @@ func TestMuxServerGetMetadata(t *testing.T) {
 			},
 			expectedServerCapabilities: &tfprotov5.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -279,6 +283,7 @@ func TestMuxServerGetMetadata(t *testing.T) {
 			},
 			expectedServerCapabilities: &tfprotov5.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -310,6 +315,7 @@ func TestMuxServerGetMetadata(t *testing.T) {
 			expectedResources: []tfprotov5.ResourceMetadata{},
 			expectedServerCapabilities: &tfprotov5.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -356,6 +362,7 @@ func TestMuxServerGetMetadata(t *testing.T) {
 			expectedResources: []tfprotov5.ResourceMetadata{},
 			expectedServerCapabilities: &tfprotov5.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -387,6 +394,7 @@ func TestMuxServerGetMetadata(t *testing.T) {
 			expectedResources: []tfprotov5.ResourceMetadata{},
 			expectedServerCapabilities: &tfprotov5.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -433,6 +441,7 @@ func TestMuxServerGetMetadata(t *testing.T) {
 			expectedResources: []tfprotov5.ResourceMetadata{},
 			expectedServerCapabilities: &tfprotov5.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -479,6 +488,7 @@ func TestMuxServerGetMetadata(t *testing.T) {
 			expectedResources: []tfprotov5.ResourceMetadata{},
 			expectedServerCapabilities: &tfprotov5.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},

--- a/tf5muxserver/mux_server_GetProviderSchema_test.go
+++ b/tf5muxserver/mux_server_GetProviderSchema_test.go
@@ -464,6 +464,7 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			},
 			expectedServerCapabilities: &tfprotov5.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -501,6 +502,7 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			expectedResourceSchemas: map[string]*tfprotov5.Schema{},
 			expectedServerCapabilities: &tfprotov5.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -538,6 +540,7 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			expectedResourceSchemas: map[string]*tfprotov5.Schema{},
 			expectedServerCapabilities: &tfprotov5.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -575,6 +578,7 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			},
 			expectedServerCapabilities: &tfprotov5.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -660,6 +664,7 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			expectedResourceSchemas: map[string]*tfprotov5.Schema{},
 			expectedServerCapabilities: &tfprotov5.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -745,6 +750,7 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			expectedResourceSchemas: map[string]*tfprotov5.Schema{},
 			expectedServerCapabilities: &tfprotov5.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -777,6 +783,7 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			},
 			expectedServerCapabilities: &tfprotov5.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -806,6 +813,11 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			},
 			expectedFunctions:       map[string]*tfprotov5.Function{},
 			expectedResourceSchemas: map[string]*tfprotov5.Schema{},
+			expectedServerCapabilities: &tfprotov5.ServerCapabilities{
+				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
+				PlanDestroy:               true,
+			},
 		},
 		"error-multiple": {
 			servers: []func() tfprotov5.ProviderServer{
@@ -848,6 +860,11 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			},
 			expectedFunctions:       map[string]*tfprotov5.Function{},
 			expectedResourceSchemas: map[string]*tfprotov5.Schema{},
+			expectedServerCapabilities: &tfprotov5.ServerCapabilities{
+				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
+				PlanDestroy:               true,
+			},
 		},
 		"warning-once": {
 			servers: []func() tfprotov5.ProviderServer{
@@ -875,6 +892,11 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			},
 			expectedFunctions:       map[string]*tfprotov5.Function{},
 			expectedResourceSchemas: map[string]*tfprotov5.Schema{},
+			expectedServerCapabilities: &tfprotov5.ServerCapabilities{
+				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
+				PlanDestroy:               true,
+			},
 		},
 		"warning-multiple": {
 			servers: []func() tfprotov5.ProviderServer{
@@ -917,6 +939,11 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			},
 			expectedFunctions:       map[string]*tfprotov5.Function{},
 			expectedResourceSchemas: map[string]*tfprotov5.Schema{},
+			expectedServerCapabilities: &tfprotov5.ServerCapabilities{
+				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
+				PlanDestroy:               true,
+			},
 		},
 		"warning-then-error": {
 			servers: []func() tfprotov5.ProviderServer{
@@ -959,6 +986,11 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			},
 			expectedFunctions:       map[string]*tfprotov5.Function{},
 			expectedResourceSchemas: map[string]*tfprotov5.Schema{},
+			expectedServerCapabilities: &tfprotov5.ServerCapabilities{
+				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
+				PlanDestroy:               true,
+			},
 		},
 	}
 
@@ -1002,6 +1034,10 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 
 			if diff := cmp.Diff(resp.ResourceSchemas, testCase.expectedResourceSchemas); diff != "" {
 				t.Errorf("resource schemas didn't match expectations: %s", diff)
+			}
+
+			if diff := cmp.Diff(resp.ServerCapabilities, testCase.expectedServerCapabilities); diff != "" {
+				t.Errorf("server capabilities didn't match expectations: %s", diff)
 			}
 		})
 	}

--- a/tf5muxserver/mux_server_MoveResourceState.go
+++ b/tf5muxserver/mux_server_MoveResourceState.go
@@ -1,0 +1,58 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tf5muxserver
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-mux/internal/logging"
+)
+
+// MoveResourceState calls the MoveResourceState method of the underlying
+// provider serving the resource.
+func (s *muxServer) MoveResourceState(ctx context.Context, req *tfprotov5.MoveResourceStateRequest) (*tfprotov5.MoveResourceStateResponse, error) {
+	rpc := "MoveResourceState"
+	ctx = logging.InitContext(ctx)
+	ctx = logging.RpcContext(ctx, rpc)
+
+	server, diags, err := s.getResourceServer(ctx, req.TargetTypeName)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if diagnosticsHasError(diags) {
+		return &tfprotov5.MoveResourceStateResponse{
+			Diagnostics: diags,
+		}, nil
+	}
+
+	ctx = logging.Tfprotov5ProviderServerContext(ctx, server)
+
+	// Remove and call server.MoveResourceState below directly.
+	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/219
+	//nolint:staticcheck // Intentionally verifying interface implementation
+	resourceServer, ok := server.(tfprotov5.ResourceServerWithMoveResourceState)
+
+	if !ok {
+		resp := &tfprotov5.MoveResourceStateResponse{
+			Diagnostics: []*tfprotov5.Diagnostic{
+				{
+					Severity: tfprotov5.DiagnosticSeverityError,
+					Summary:  "MoveResourceState Not Implemented",
+					Detail: "A MoveResourceState call was received by the provider, however the provider does not implement MoveResourceState. " +
+						"Either upgrade the provider to a version that implements MoveResourceState or this is a bug in Terraform that should be reported to the Terraform maintainers.",
+				},
+			},
+		}
+
+		return resp, nil
+	}
+
+	logging.MuxTrace(ctx, "calling downstream server")
+
+	// return server.MoveResourceState(ctx, req)
+	return resourceServer.MoveResourceState(ctx, req)
+}

--- a/tf5muxserver/mux_server_MoveResourceState_test.go
+++ b/tf5muxserver/mux_server_MoveResourceState_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tf5muxserver_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+
+	"github.com/hashicorp/terraform-plugin-mux/internal/tf5testserver"
+	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
+)
+
+func TestMuxServerMoveResourceState(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	testServer1 := &tf5testserver.TestServer{
+		GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{
+			ResourceSchemas: map[string]*tfprotov5.Schema{
+				"test_resource1": {},
+			},
+		},
+	}
+	testServer2 := &tf5testserver.TestServer{
+		GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{
+			ResourceSchemas: map[string]*tfprotov5.Schema{
+				"test_resource2": {},
+			},
+		},
+	}
+
+	servers := []func() tfprotov5.ProviderServer{testServer1.ProviderServer, testServer2.ProviderServer}
+	muxServer, err := tf5muxserver.NewMuxServer(ctx, servers...)
+
+	if err != nil {
+		t.Fatalf("unexpected error setting up factory: %s", err)
+	}
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/219
+	//nolint:staticcheck // Intentionally verifying interface implementation
+	resourceServer, ok := muxServer.ProviderServer().(tfprotov5.ResourceServerWithMoveResourceState)
+
+	if !ok {
+		t.Fatal("muxServer should implement tfprotov5.ResourceServerWithMoveResourceState")
+	}
+
+	// _, err = muxServer.ProviderServer().MoveResourceState(ctx, &tfprotov5.MoveResourceStateRequest{
+	_, err = resourceServer.MoveResourceState(ctx, &tfprotov5.MoveResourceStateRequest{
+		TargetTypeName: "test_resource1",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !testServer1.MoveResourceStateCalled["test_resource1"] {
+		t.Errorf("expected test_resource1 MoveResourceState to be called on server1")
+	}
+
+	if testServer2.MoveResourceStateCalled["test_resource1"] {
+		t.Errorf("unexpected test_resource1 MoveResourceState called on server2")
+	}
+
+	// _, err = muxServer.ProviderServer().MoveResourceState(ctx, &tfprotov5.MoveResourceStateRequest{
+	_, err = resourceServer.MoveResourceState(ctx, &tfprotov5.MoveResourceStateRequest{
+		TargetTypeName: "test_resource2",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if testServer1.MoveResourceStateCalled["test_resource2"] {
+		t.Errorf("unexpected test_resource2 MoveResourceState called on server1")
+	}
+
+	if !testServer2.MoveResourceStateCalled["test_resource2"] {
+		t.Errorf("expected test_resource2 MoveResourceState to be called on server2")
+	}
+}

--- a/tf5muxserver/server_capabilities.go
+++ b/tf5muxserver/server_capabilities.go
@@ -10,6 +10,7 @@ import "github.com/hashicorp/terraform-plugin-go/tfprotov5"
 // servers if they are not compatible with a capability.
 var serverCapabilities = &tfprotov5.ServerCapabilities{
 	GetProviderSchemaOptional: true,
+	MoveResourceState:         true,
 	PlanDestroy:               true,
 }
 

--- a/tf5to6server/tf5to6server.go
+++ b/tf5to6server/tf5to6server.go
@@ -28,6 +28,15 @@ func UpgradeServer(_ context.Context, v5server func() tfprotov5.ProviderServer) 
 
 var _ tfprotov6.ProviderServer = v5tov6Server{}
 
+// Temporarily verify that v5tov6Server implements new RPCs correctly.
+// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
+// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/219
+var (
+	_ tfprotov6.FunctionServer = v5tov6Server{}
+	//nolint:staticcheck // Intentional verification of interface implementation.
+	_ tfprotov6.ResourceServerWithMoveResourceState = v5tov6Server{}
+)
+
 type v5tov6Server struct {
 	v5Server tfprotov5.ProviderServer
 }
@@ -142,6 +151,39 @@ func (s v5tov6Server) ImportResourceState(ctx context.Context, req *tfprotov6.Im
 	}
 
 	return tfprotov5tov6.ImportResourceStateResponse(v5Resp), nil
+}
+
+func (s v5tov6Server) MoveResourceState(ctx context.Context, req *tfprotov6.MoveResourceStateRequest) (*tfprotov6.MoveResourceStateResponse, error) {
+	// Remove and call s.v5Server.MoveResourceState below directly.
+	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/219
+	//nolint:staticcheck // Intentional verification of interface implementation.
+	resourceServer, ok := s.v5Server.(tfprotov5.ResourceServerWithMoveResourceState)
+
+	if !ok {
+		v6Resp := &tfprotov6.MoveResourceStateResponse{
+			Diagnostics: []*tfprotov6.Diagnostic{
+				{
+					Severity: tfprotov6.DiagnosticSeverityError,
+					Summary:  "MoveResourceState Not Implemented",
+					Detail: "A MoveResourceState call was received by the provider, however the provider does not implement the RPC. " +
+						"Either upgrade the provider to a version that implements MoveResourceState or this is a bug in Terraform that should be reported to the Terraform maintainers.",
+				},
+			},
+		}
+
+		return v6Resp, nil
+	}
+
+	v5Req := tfprotov6tov5.MoveResourceStateRequest(req)
+	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/219
+	// v5Resp, err := s.v5Server.MoveResourceState(ctx, v5Req)
+	v5Resp, err := resourceServer.MoveResourceState(ctx, v5Req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfprotov5tov6.MoveResourceStateResponse(v5Resp), nil
 }
 
 func (s v5tov6Server) PlanResourceChange(ctx context.Context, req *tfprotov6.PlanResourceChangeRequest) (*tfprotov6.PlanResourceChangeResponse, error) {

--- a/tf5to6server/tf5to6server_test.go
+++ b/tf5to6server/tf5to6server_test.go
@@ -356,6 +356,46 @@ func TestV6ToV5ServerImportResourceState(t *testing.T) {
 	}
 }
 
+func TestV5ToV6ServerMoveResourceState(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v5server := &tf5testserver.TestServer{
+		GetProviderSchemaResponse: &tfprotov5.GetProviderSchemaResponse{
+			ResourceSchemas: map[string]*tfprotov5.Schema{
+				"test_resource": {},
+			},
+		},
+	}
+
+	v6server, err := tf5to6server.UpgradeServer(context.Background(), v5server.ProviderServer)
+
+	if err != nil {
+		t.Fatalf("unexpected error downgrading server: %s", err)
+	}
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/219
+	//nolint:staticcheck // Intentional verification of interface implementation.
+	resourceServer, ok := v6server.(tfprotov6.ResourceServerWithMoveResourceState)
+
+	if !ok {
+		t.Fatal("v5server should implement tfprotov6.ResourceServerWithMoveResourceState")
+	}
+
+	// _, err = v6server.MoveResourceState(ctx, &tfprotov6.MoveResourceStateRequest{
+	_, err = resourceServer.MoveResourceState(ctx, &tfprotov6.MoveResourceStateRequest{
+		TargetTypeName: "test_resource",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !v5server.MoveResourceStateCalled["test_resource"] {
+		t.Errorf("expected test_resource MoveResourceState to be called")
+	}
+}
+
 func TestV6ToV5ServerPlanResourceChange(t *testing.T) {
 	t.Parallel()
 

--- a/tf6muxserver/mux_server.go
+++ b/tf6muxserver/mux_server.go
@@ -15,6 +15,15 @@ import (
 
 var _ tfprotov6.ProviderServer = &muxServer{}
 
+// Temporarily verify that v5tov6Server implements new RPCs correctly.
+// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
+// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/219
+var (
+	_ tfprotov6.FunctionServer = &muxServer{}
+	//nolint:staticcheck // Intentional verification of interface implementation.
+	_ tfprotov6.ResourceServerWithMoveResourceState = &muxServer{}
+)
+
 // muxServer is a gRPC server implementation that stands in front of other
 // gRPC servers, routing requests to them as if they were a single server. It
 // should always be instantiated by calling NewMuxServer().

--- a/tf6muxserver/mux_server_GetMetadata_test.go
+++ b/tf6muxserver/mux_server_GetMetadata_test.go
@@ -110,6 +110,7 @@ func TestMuxServerGetMetadata(t *testing.T) {
 			},
 			expectedServerCapabilities: &tfprotov6.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -153,6 +154,7 @@ func TestMuxServerGetMetadata(t *testing.T) {
 			expectedResources: []tfprotov6.ResourceMetadata{},
 			expectedServerCapabilities: &tfprotov6.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -196,6 +198,7 @@ func TestMuxServerGetMetadata(t *testing.T) {
 			expectedResources: []tfprotov6.ResourceMetadata{},
 			expectedServerCapabilities: &tfprotov6.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -239,6 +242,7 @@ func TestMuxServerGetMetadata(t *testing.T) {
 			},
 			expectedServerCapabilities: &tfprotov6.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -279,6 +283,7 @@ func TestMuxServerGetMetadata(t *testing.T) {
 			},
 			expectedServerCapabilities: &tfprotov6.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -310,6 +315,7 @@ func TestMuxServerGetMetadata(t *testing.T) {
 			expectedResources: []tfprotov6.ResourceMetadata{},
 			expectedServerCapabilities: &tfprotov6.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -356,6 +362,7 @@ func TestMuxServerGetMetadata(t *testing.T) {
 			expectedResources: []tfprotov6.ResourceMetadata{},
 			expectedServerCapabilities: &tfprotov6.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -387,6 +394,7 @@ func TestMuxServerGetMetadata(t *testing.T) {
 			expectedResources: []tfprotov6.ResourceMetadata{},
 			expectedServerCapabilities: &tfprotov6.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -433,6 +441,7 @@ func TestMuxServerGetMetadata(t *testing.T) {
 			expectedResources: []tfprotov6.ResourceMetadata{},
 			expectedServerCapabilities: &tfprotov6.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -479,6 +488,7 @@ func TestMuxServerGetMetadata(t *testing.T) {
 			expectedResources: []tfprotov6.ResourceMetadata{},
 			expectedServerCapabilities: &tfprotov6.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},

--- a/tf6muxserver/mux_server_GetProviderSchema_test.go
+++ b/tf6muxserver/mux_server_GetProviderSchema_test.go
@@ -464,6 +464,7 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			},
 			expectedServerCapabilities: &tfprotov6.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -501,6 +502,7 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			expectedResourceSchemas: map[string]*tfprotov6.Schema{},
 			expectedServerCapabilities: &tfprotov6.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -538,6 +540,7 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			expectedResourceSchemas: map[string]*tfprotov6.Schema{},
 			expectedServerCapabilities: &tfprotov6.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -575,6 +578,7 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			},
 			expectedServerCapabilities: &tfprotov6.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -660,6 +664,7 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			expectedResourceSchemas: map[string]*tfprotov6.Schema{},
 			expectedServerCapabilities: &tfprotov6.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -745,6 +750,7 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			expectedResourceSchemas: map[string]*tfprotov6.Schema{},
 			expectedServerCapabilities: &tfprotov6.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -776,6 +782,7 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			},
 			expectedServerCapabilities: &tfprotov6.ServerCapabilities{
 				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
 				PlanDestroy:               true,
 			},
 		},
@@ -805,6 +812,11 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			},
 			expectedFunctions:       map[string]*tfprotov6.Function{},
 			expectedResourceSchemas: map[string]*tfprotov6.Schema{},
+			expectedServerCapabilities: &tfprotov6.ServerCapabilities{
+				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
+				PlanDestroy:               true,
+			},
 		},
 		"error-multiple": {
 			servers: []func() tfprotov6.ProviderServer{
@@ -847,6 +859,11 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			},
 			expectedFunctions:       map[string]*tfprotov6.Function{},
 			expectedResourceSchemas: map[string]*tfprotov6.Schema{},
+			expectedServerCapabilities: &tfprotov6.ServerCapabilities{
+				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
+				PlanDestroy:               true,
+			},
 		},
 		"warning-once": {
 			servers: []func() tfprotov6.ProviderServer{
@@ -874,6 +891,11 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			},
 			expectedFunctions:       map[string]*tfprotov6.Function{},
 			expectedResourceSchemas: map[string]*tfprotov6.Schema{},
+			expectedServerCapabilities: &tfprotov6.ServerCapabilities{
+				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
+				PlanDestroy:               true,
+			},
 		},
 		"warning-multiple": {
 			servers: []func() tfprotov6.ProviderServer{
@@ -916,6 +938,11 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			},
 			expectedFunctions:       map[string]*tfprotov6.Function{},
 			expectedResourceSchemas: map[string]*tfprotov6.Schema{},
+			expectedServerCapabilities: &tfprotov6.ServerCapabilities{
+				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
+				PlanDestroy:               true,
+			},
 		},
 		"warning-then-error": {
 			servers: []func() tfprotov6.ProviderServer{
@@ -958,6 +985,11 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 			},
 			expectedFunctions:       map[string]*tfprotov6.Function{},
 			expectedResourceSchemas: map[string]*tfprotov6.Schema{},
+			expectedServerCapabilities: &tfprotov6.ServerCapabilities{
+				GetProviderSchemaOptional: true,
+				MoveResourceState:         true,
+				PlanDestroy:               true,
+			},
 		},
 	}
 
@@ -1001,6 +1033,10 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 
 			if diff := cmp.Diff(resp.ResourceSchemas, testCase.expectedResourceSchemas); diff != "" {
 				t.Errorf("resource schemas didn't match expectations: %s", diff)
+			}
+
+			if diff := cmp.Diff(resp.ServerCapabilities, testCase.expectedServerCapabilities); diff != "" {
+				t.Errorf("server capabilities didn't match expectations: %s", diff)
 			}
 		})
 	}

--- a/tf6muxserver/mux_server_MoveResourceState.go
+++ b/tf6muxserver/mux_server_MoveResourceState.go
@@ -1,0 +1,58 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tf6muxserver
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-mux/internal/logging"
+)
+
+// MoveResourceState calls the MoveResourceState method of the underlying
+// provider serving the resource.
+func (s *muxServer) MoveResourceState(ctx context.Context, req *tfprotov6.MoveResourceStateRequest) (*tfprotov6.MoveResourceStateResponse, error) {
+	rpc := "MoveResourceState"
+	ctx = logging.InitContext(ctx)
+	ctx = logging.RpcContext(ctx, rpc)
+
+	server, diags, err := s.getResourceServer(ctx, req.TargetTypeName)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if diagnosticsHasError(diags) {
+		return &tfprotov6.MoveResourceStateResponse{
+			Diagnostics: diags,
+		}, nil
+	}
+
+	ctx = logging.Tfprotov6ProviderServerContext(ctx, server)
+
+	// Remove and call server.MoveResourceState below directly.
+	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/219
+	//nolint:staticcheck // Intentionally verifying interface implementation
+	resourceServer, ok := server.(tfprotov6.ResourceServerWithMoveResourceState)
+
+	if !ok {
+		resp := &tfprotov6.MoveResourceStateResponse{
+			Diagnostics: []*tfprotov6.Diagnostic{
+				{
+					Severity: tfprotov6.DiagnosticSeverityError,
+					Summary:  "MoveResourceState Not Implemented",
+					Detail: "A MoveResourceState call was received by the provider, however the provider does not implement MoveResourceState. " +
+						"Either upgrade the provider to a version that implements MoveResourceState or this is a bug in Terraform that should be reported to the Terraform maintainers.",
+				},
+			},
+		}
+
+		return resp, nil
+	}
+
+	logging.MuxTrace(ctx, "calling downstream server")
+
+	// return server.MoveResourceState(ctx, req)
+	return resourceServer.MoveResourceState(ctx, req)
+}

--- a/tf6muxserver/mux_server_MoveResourceState_test.go
+++ b/tf6muxserver/mux_server_MoveResourceState_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tf6muxserver_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+
+	"github.com/hashicorp/terraform-plugin-mux/internal/tf6testserver"
+	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
+)
+
+func TestMuxServerMoveResourceState(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	testServer1 := &tf6testserver.TestServer{
+		GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{
+			ResourceSchemas: map[string]*tfprotov6.Schema{
+				"test_resource1": {},
+			},
+		},
+	}
+	testServer2 := &tf6testserver.TestServer{
+		GetProviderSchemaResponse: &tfprotov6.GetProviderSchemaResponse{
+			ResourceSchemas: map[string]*tfprotov6.Schema{
+				"test_resource2": {},
+			},
+		},
+	}
+
+	servers := []func() tfprotov6.ProviderServer{testServer1.ProviderServer, testServer2.ProviderServer}
+	muxServer, err := tf6muxserver.NewMuxServer(ctx, servers...)
+
+	if err != nil {
+		t.Fatalf("unexpected error setting up factory: %s", err)
+	}
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/219
+	//nolint:staticcheck // Intentionally verifying interface implementation
+	resourceServer, ok := muxServer.ProviderServer().(tfprotov6.ResourceServerWithMoveResourceState)
+
+	if !ok {
+		t.Fatal("muxServer should implement tfprotov6.ResourceServerWithMoveResourceState")
+	}
+
+	// _, err = muxServer.ProviderServer().MoveResourceState(ctx, &tfprotov6.MoveResourceStateRequest{
+	_, err = resourceServer.MoveResourceState(ctx, &tfprotov6.MoveResourceStateRequest{
+		TargetTypeName: "test_resource1",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !testServer1.MoveResourceStateCalled["test_resource1"] {
+		t.Errorf("expected test_resource1 MoveResourceState to be called on server1")
+	}
+
+	if testServer2.MoveResourceStateCalled["test_resource1"] {
+		t.Errorf("unexpected test_resource1 MoveResourceState called on server2")
+	}
+
+	// _, err = muxServer.ProviderServer().MoveResourceState(ctx, &tfprotov6.MoveResourceStateRequest{
+	_, err = resourceServer.MoveResourceState(ctx, &tfprotov6.MoveResourceStateRequest{
+		TargetTypeName: "test_resource2",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if testServer1.MoveResourceStateCalled["test_resource2"] {
+		t.Errorf("unexpected test_resource2 MoveResourceState called on server1")
+	}
+
+	if !testServer2.MoveResourceStateCalled["test_resource2"] {
+		t.Errorf("expected test_resource2 MoveResourceState to be called on server2")
+	}
+}

--- a/tf6muxserver/server_capabilities.go
+++ b/tf6muxserver/server_capabilities.go
@@ -10,6 +10,7 @@ import "github.com/hashicorp/terraform-plugin-go/tfprotov6"
 // servers if they are not compatible with a capability.
 var serverCapabilities = &tfprotov6.ServerCapabilities{
 	GetProviderSchemaOptional: true,
+	MoveResourceState:         true,
 	PlanDestroy:               true,
 }
 


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-go/pull/364

The next versions of the plugin protocol (5.5/6.5) include support for the MoveResourceState RPC and server capability. This change includes initial implementation of the new RPC in all server implementations.