### PR TITLE
all: Remove type assertions for Function and MoveResourceState RPC implementations

### DIFF
--- a/tf5muxserver/mux_server.go
+++ b/tf5muxserver/mux_server.go
@@ -15,13 +15,6 @@ import (
 
 var _ tfprotov5.ProviderServer = &muxServer{}
 
-// Temporarily verify that v5tov6Server implements new RPCs correctly.
-// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/219
-var (
-	//nolint:staticcheck // Intentional verification of interface implementation.
-	_ tfprotov5.ResourceServerWithMoveResourceState = &muxServer{}
-)
-
 // muxServer is a gRPC server implementation that stands in front of other
 // gRPC servers, routing requests to them as if they were a single server. It
 // should always be instantiated by calling NewMuxServer().

--- a/tf5muxserver/mux_server.go
+++ b/tf5muxserver/mux_server.go
@@ -16,10 +16,8 @@ import (
 var _ tfprotov5.ProviderServer = &muxServer{}
 
 // Temporarily verify that v5tov6Server implements new RPCs correctly.
-// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
 // Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/219
 var (
-	_ tfprotov5.FunctionServer = &muxServer{}
 	//nolint:staticcheck // Intentional verification of interface implementation.
 	_ tfprotov5.ResourceServerWithMoveResourceState = &muxServer{}
 )

--- a/tf5muxserver/mux_server_CallFunction.go
+++ b/tf5muxserver/mux_server_CallFunction.go
@@ -46,24 +46,7 @@ func (s *muxServer) CallFunction(ctx context.Context, req *tfprotov5.CallFunctio
 	}
 
 	ctx = logging.Tfprotov5ProviderServerContext(ctx, server)
-
-	// Remove and call server.CallFunction below directly.
-	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-	functionServer, ok := server.(tfprotov5.FunctionServer)
-
-	if !ok {
-		resp := &tfprotov5.CallFunctionResponse{
-			Error: &tfprotov5.FunctionError{
-				Text: "Provider Functions Not Implemented: A provider-defined function call was received by the provider, however the provider does not implement functions. " +
-					"Either upgrade the provider to a version that implements provider-defined functions or this is a bug in Terraform that should be reported to the Terraform maintainers.",
-			},
-		}
-
-		return resp, nil
-	}
-
 	logging.MuxTrace(ctx, "calling downstream server")
 
-	// return server.CallFunction(ctx, req)
-	return functionServer.CallFunction(ctx, req)
+	return server.CallFunction(ctx, req)
 }

--- a/tf5muxserver/mux_server_CallFunction_test.go
+++ b/tf5muxserver/mux_server_CallFunction_test.go
@@ -39,15 +39,7 @@ func TestMuxServerCallFunction(t *testing.T) {
 		t.Fatalf("unexpected error setting up factory: %s", err)
 	}
 
-	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-	functionServer, ok := muxServer.ProviderServer().(tfprotov5.FunctionServer)
-
-	if !ok {
-		t.Fatal("muxServer should implement tfprotov5.FunctionServer")
-	}
-
-	// _, err = muxServer.ProviderServer().CallFunction(ctx, &tfprotov5.CallFunctionRequest{
-	_, err = functionServer.CallFunction(ctx, &tfprotov5.CallFunctionRequest{
+	_, err = muxServer.ProviderServer().CallFunction(ctx, &tfprotov5.CallFunctionRequest{
 		Name: "test_function1",
 	})
 
@@ -63,8 +55,7 @@ func TestMuxServerCallFunction(t *testing.T) {
 		t.Errorf("unexpected test_function1 CallFunction called on server2")
 	}
 
-	// _, err = muxServer.ProviderServer().CallFunction(ctx, &tfprotov5.CallFunctionRequest{
-	_, err = functionServer.CallFunction(ctx, &tfprotov5.CallFunctionRequest{
+	_, err = muxServer.ProviderServer().CallFunction(ctx, &tfprotov5.CallFunctionRequest{
 		Name: "test_function2",
 	})
 

--- a/tf5muxserver/mux_server_GetFunctions.go
+++ b/tf5muxserver/mux_server_GetFunctions.go
@@ -30,18 +30,9 @@ func (s *muxServer) GetFunctions(ctx context.Context, req *tfprotov5.GetFunction
 	for _, server := range s.servers {
 		ctx := logging.Tfprotov5ProviderServerContext(ctx, server)
 
-		// Remove and call server.GetFunctions below directly.
-		// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-		functionServer, ok := server.(tfprotov5.FunctionServer)
-
-		if !ok {
-			continue
-		}
-
 		logging.MuxTrace(ctx, "calling downstream server")
 
-		// serverResp, err := server.GetFunctions(ctx, &tfprotov5.GetFunctionsRequest{})
-		serverResp, err := functionServer.GetFunctions(ctx, &tfprotov5.GetFunctionsRequest{})
+		serverResp, err := server.GetFunctions(ctx, &tfprotov5.GetFunctionsRequest{})
 
 		if err != nil {
 			return resp, fmt.Errorf("error calling GetFunctions for %T: %w", server, err)

--- a/tf5muxserver/mux_server_GetFunctions_test.go
+++ b/tf5muxserver/mux_server_GetFunctions_test.go
@@ -311,15 +311,7 @@ func TestMuxServerGetFunctions(t *testing.T) {
 				t.Fatalf("unexpected error: %s", err)
 			}
 
-			// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-			functionServer, ok := muxServer.ProviderServer().(tfprotov5.FunctionServer)
-
-			if !ok {
-				t.Fatal("muxServer should implement tfprotov5.FunctionServer")
-			}
-
-			// resp, err := muxServer.ProviderServer().GetFunctions(context.Background(), &tfprotov5.GetFunctionsRequest{})
-			resp, err := functionServer.GetFunctions(context.Background(), &tfprotov5.GetFunctionsRequest{})
+			resp, err := muxServer.ProviderServer().GetFunctions(context.Background(), &tfprotov5.GetFunctionsRequest{})
 
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err)

--- a/tf5muxserver/mux_server_MoveResourceState.go
+++ b/tf5muxserver/mux_server_MoveResourceState.go
@@ -30,29 +30,7 @@ func (s *muxServer) MoveResourceState(ctx context.Context, req *tfprotov5.MoveRe
 	}
 
 	ctx = logging.Tfprotov5ProviderServerContext(ctx, server)
-
-	// Remove and call server.MoveResourceState below directly.
-	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/219
-	//nolint:staticcheck // Intentionally verifying interface implementation
-	resourceServer, ok := server.(tfprotov5.ResourceServerWithMoveResourceState)
-
-	if !ok {
-		resp := &tfprotov5.MoveResourceStateResponse{
-			Diagnostics: []*tfprotov5.Diagnostic{
-				{
-					Severity: tfprotov5.DiagnosticSeverityError,
-					Summary:  "MoveResourceState Not Implemented",
-					Detail: "A MoveResourceState call was received by the provider, however the provider does not implement MoveResourceState. " +
-						"Either upgrade the provider to a version that implements MoveResourceState or this is a bug in Terraform that should be reported to the Terraform maintainers.",
-				},
-			},
-		}
-
-		return resp, nil
-	}
-
 	logging.MuxTrace(ctx, "calling downstream server")
 
-	// return server.MoveResourceState(ctx, req)
-	return resourceServer.MoveResourceState(ctx, req)
+	return server.MoveResourceState(ctx, req)
 }

--- a/tf5muxserver/mux_server_MoveResourceState_test.go
+++ b/tf5muxserver/mux_server_MoveResourceState_test.go
@@ -39,16 +39,7 @@ func TestMuxServerMoveResourceState(t *testing.T) {
 		t.Fatalf("unexpected error setting up factory: %s", err)
 	}
 
-	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/219
-	//nolint:staticcheck // Intentionally verifying interface implementation
-	resourceServer, ok := muxServer.ProviderServer().(tfprotov5.ResourceServerWithMoveResourceState)
-
-	if !ok {
-		t.Fatal("muxServer should implement tfprotov5.ResourceServerWithMoveResourceState")
-	}
-
-	// _, err = muxServer.ProviderServer().MoveResourceState(ctx, &tfprotov5.MoveResourceStateRequest{
-	_, err = resourceServer.MoveResourceState(ctx, &tfprotov5.MoveResourceStateRequest{
+	_, err = muxServer.ProviderServer().MoveResourceState(ctx, &tfprotov5.MoveResourceStateRequest{
 		TargetTypeName: "test_resource1",
 	})
 
@@ -64,8 +55,7 @@ func TestMuxServerMoveResourceState(t *testing.T) {
 		t.Errorf("unexpected test_resource1 MoveResourceState called on server2")
 	}
 
-	// _, err = muxServer.ProviderServer().MoveResourceState(ctx, &tfprotov5.MoveResourceStateRequest{
-	_, err = resourceServer.MoveResourceState(ctx, &tfprotov5.MoveResourceStateRequest{
+	_, err = muxServer.ProviderServer().MoveResourceState(ctx, &tfprotov5.MoveResourceStateRequest{
 		TargetTypeName: "test_resource2",
 	})
 

--- a/tf5muxserver/mux_server_test.go
+++ b/tf5muxserver/mux_server_test.go
@@ -435,15 +435,7 @@ func TestMuxServerGetFunctionServer_GetProviderSchema(t *testing.T) {
 	terraformOp := func() {
 		defer wg.Done()
 
-		// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-		functionServer, ok := muxServer.ProviderServer().(tfprotov5.FunctionServer)
-
-		if !ok {
-			t.Error("muxServer should implement tfprotov5.FunctionServer")
-		}
-
-		// _, _ = muxServer.ProviderServer().CallFunction(ctx, &tfprotov5.CallFunctionRequest{
-		_, _ = functionServer.CallFunction(ctx, &tfprotov5.CallFunctionRequest{
+		_, _ = muxServer.ProviderServer().CallFunction(ctx, &tfprotov5.CallFunctionRequest{
 			Name: "test_function1",
 		})
 	}
@@ -502,15 +494,7 @@ func TestMuxServerGetFunctionServer_GetProviderSchema_Duplicate(t *testing.T) {
 	terraformOp := func() {
 		defer wg.Done()
 
-		// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-		functionServer, ok := muxServer.ProviderServer().(tfprotov5.FunctionServer)
-
-		if !ok {
-			t.Error("muxServer should implement tfprotov5.FunctionServer")
-		}
-
-		// resp, _ := muxServer.ProviderServer().CallFunction(ctx, &tfprotov5.CallFunctionRequest{
-		resp, _ := functionServer.CallFunction(ctx, &tfprotov5.CallFunctionRequest{
+		resp, _ := muxServer.ProviderServer().CallFunction(ctx, &tfprotov5.CallFunctionRequest{
 			Name: "test_function",
 		})
 
@@ -574,15 +558,7 @@ func TestMuxServerGetFunctionServer_GetMetadata(t *testing.T) {
 	terraformOp := func() {
 		defer wg.Done()
 
-		// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-		functionServer, ok := muxServer.ProviderServer().(tfprotov5.FunctionServer)
-
-		if !ok {
-			t.Error("muxServer should implement tfprotov5.FunctionServer")
-		}
-
-		// _, _ = muxServer.ProviderServer().CallFunction(ctx, &tfprotov5.CallFunctionRequest{
-		_, _ = functionServer.CallFunction(ctx, &tfprotov5.CallFunctionRequest{
+		_, _ = muxServer.ProviderServer().CallFunction(ctx, &tfprotov5.CallFunctionRequest{
 			Name: "test_function1",
 		})
 	}
@@ -645,15 +621,7 @@ func TestMuxServerGetFunctionServer_GetMetadata_Duplicate(t *testing.T) {
 	terraformOp := func() {
 		defer wg.Done()
 
-		// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-		functionServer, ok := muxServer.ProviderServer().(tfprotov5.FunctionServer)
-
-		if !ok {
-			t.Error("muxServer should implement tfprotov5.FunctionServer")
-		}
-
-		// resp, _ := muxServer.ProviderServer().CallFunction(ctx, &tfprotov5.CallFunctionRequest{
-		resp, _ := functionServer.CallFunction(ctx, &tfprotov5.CallFunctionRequest{
+		resp, _ := muxServer.ProviderServer().CallFunction(ctx, &tfprotov5.CallFunctionRequest{
 			Name: "test_function",
 		})
 
@@ -715,15 +683,7 @@ func TestMuxServerGetFunctionServer_GetMetadata_Partial(t *testing.T) {
 	terraformOp := func() {
 		defer wg.Done()
 
-		// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-		functionServer, ok := muxServer.ProviderServer().(tfprotov5.FunctionServer)
-
-		if !ok {
-			t.Error("muxServer should implement tfprotov5.FunctionServer")
-		}
-
-		// _, _ = muxServer.ProviderServer().CallFunction(ctx, &tfprotov5.CallFunctionRequest{
-		_, _ = functionServer.CallFunction(ctx, &tfprotov5.CallFunctionRequest{
+		_, _ = muxServer.ProviderServer().CallFunction(ctx, &tfprotov5.CallFunctionRequest{
 			Name: "test_function1",
 		})
 	}
@@ -785,15 +745,7 @@ func TestMuxServerGetFunctionServer_Missing(t *testing.T) {
 	terraformOp := func() {
 		defer wg.Done()
 
-		// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-		functionServer, ok := muxServer.ProviderServer().(tfprotov5.FunctionServer)
-
-		if !ok {
-			t.Error("muxServer should implement tfprotov5.FunctionServer")
-		}
-
-		// resp, _ := muxServer.ProviderServer().CallFunction(ctx, &tfprotov5.CallFunctionRequest{
-		resp, _ := functionServer.CallFunction(ctx, &tfprotov5.CallFunctionRequest{
+		resp, _ := muxServer.ProviderServer().CallFunction(ctx, &tfprotov5.CallFunctionRequest{
 			Name: "test_function_nonexistent",
 		})
 

--- a/tf5to6server/tf5to6server.go
+++ b/tf5to6server/tf5to6server.go
@@ -30,10 +30,8 @@ func UpgradeServer(_ context.Context, v5server func() tfprotov5.ProviderServer) 
 var _ tfprotov6.ProviderServer = v5tov6Server{}
 
 // Temporarily verify that v5tov6Server implements new RPCs correctly.
-// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
 // Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/219
 var (
-	_ tfprotov6.FunctionServer = v5tov6Server{}
 	//nolint:staticcheck // Intentional verification of interface implementation.
 	_ tfprotov6.ResourceServerWithMoveResourceState = v5tov6Server{}
 )
@@ -54,26 +52,9 @@ func (s v5tov6Server) ApplyResourceChange(ctx context.Context, req *tfprotov6.Ap
 }
 
 func (s v5tov6Server) CallFunction(ctx context.Context, req *tfprotov6.CallFunctionRequest) (*tfprotov6.CallFunctionResponse, error) {
-	// Remove and call s.v5Server.CallFunction below directly.
-	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-	functionServer, ok := s.v5Server.(tfprotov5.FunctionServer)
-
-	if !ok {
-		v6Resp := &tfprotov6.CallFunctionResponse{
-			Error: &tfprotov6.FunctionError{
-				Text: "Provider Functions Not Implemented: A provider-defined function call was received by the provider, however the provider does not implement functions. " +
-					"Either upgrade the provider to a version that implements provider-defined functions or this is a bug in Terraform that should be reported to the Terraform maintainers.",
-			},
-		}
-
-		return v6Resp, nil
-	}
-
 	v5Req := tfprotov6tov5.CallFunctionRequest(req)
-	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-	// v5Resp, err := s.v5Server.CallFunction(ctx, v5Req)
-	v5Resp, err := functionServer.CallFunction(ctx, v5Req)
 
+	v5Resp, err := s.v5Server.CallFunction(ctx, v5Req)
 	if err != nil {
 		return nil, err
 	}
@@ -93,23 +74,9 @@ func (s v5tov6Server) ConfigureProvider(ctx context.Context, req *tfprotov6.Conf
 }
 
 func (s v5tov6Server) GetFunctions(ctx context.Context, req *tfprotov6.GetFunctionsRequest) (*tfprotov6.GetFunctionsResponse, error) {
-	// Remove and call s.v5Server.GetFunctions below directly.
-	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-	functionServer, ok := s.v5Server.(tfprotov5.FunctionServer)
-
-	if !ok {
-		v6Resp := &tfprotov6.GetFunctionsResponse{
-			Functions: map[string]*tfprotov6.Function{},
-		}
-
-		return v6Resp, nil
-	}
-
 	v5Req := tfprotov6tov5.GetFunctionsRequest(req)
-	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-	// v5Resp, err := s.v5Server.GetFunctions(ctx, v5Req)
-	v5Resp, err := functionServer.GetFunctions(ctx, v5Req)
 
+	v5Resp, err := s.v5Server.GetFunctions(ctx, v5Req)
 	if err != nil {
 		return nil, err
 	}

--- a/tf5to6server/tf5to6server_test.go
+++ b/tf5to6server/tf5to6server_test.go
@@ -358,16 +358,7 @@ func TestV5ToV6ServerMoveResourceState(t *testing.T) {
 		t.Fatalf("unexpected error downgrading server: %s", err)
 	}
 
-	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/219
-	//nolint:staticcheck // Intentional verification of interface implementation.
-	resourceServer, ok := v6server.(tfprotov6.ResourceServerWithMoveResourceState)
-
-	if !ok {
-		t.Fatal("v5server should implement tfprotov6.ResourceServerWithMoveResourceState")
-	}
-
-	// _, err = v6server.MoveResourceState(ctx, &tfprotov6.MoveResourceStateRequest{
-	_, err = resourceServer.MoveResourceState(ctx, &tfprotov6.MoveResourceStateRequest{
+	_, err = v6server.MoveResourceState(ctx, &tfprotov6.MoveResourceStateRequest{
 		TargetTypeName: "test_resource",
 	})
 

--- a/tf5to6server/tf5to6server_test.go
+++ b/tf5to6server/tf5to6server_test.go
@@ -178,15 +178,7 @@ func TestV6ToV5ServerCallFunction(t *testing.T) {
 		t.Fatalf("unexpected error upgrading server: %s", err)
 	}
 
-	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-	functionServer, ok := v6server.(tfprotov6.FunctionServer)
-
-	if !ok {
-		t.Fatal("v6server should implement tfprotov6.FunctionServer")
-	}
-
-	//_, err = v6server.CallFunction(ctx, &tfprotov6.CallFunctionRequest{
-	_, err = functionServer.CallFunction(ctx, &tfprotov6.CallFunctionRequest{
+	_, err = v6server.CallFunction(ctx, &tfprotov6.CallFunctionRequest{
 		Name: "test_function",
 	})
 
@@ -246,15 +238,7 @@ func TestV6ToV5ServerGetFunctions(t *testing.T) {
 		t.Fatalf("unexpected error upgrading server: %s", err)
 	}
 
-	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-	functionServer, ok := v6server.(tfprotov6.FunctionServer)
-
-	if !ok {
-		t.Fatal("v6server should implement tfprotov6.FunctionServer")
-	}
-
-	//_, err = v6server.GetFunction(ctx, &tfprotov6.GetFunctionRequest{})
-	_, err = functionServer.GetFunctions(ctx, &tfprotov6.GetFunctionsRequest{})
+	_, err = v6server.GetFunctions(ctx, &tfprotov6.GetFunctionsRequest{})
 
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)

--- a/tf6muxserver/mux_server.go
+++ b/tf6muxserver/mux_server.go
@@ -15,13 +15,6 @@ import (
 
 var _ tfprotov6.ProviderServer = &muxServer{}
 
-// Temporarily verify that v5tov6Server implements new RPCs correctly.
-// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/219
-var (
-	//nolint:staticcheck // Intentional verification of interface implementation.
-	_ tfprotov6.ResourceServerWithMoveResourceState = &muxServer{}
-)
-
 // muxServer is a gRPC server implementation that stands in front of other
 // gRPC servers, routing requests to them as if they were a single server. It
 // should always be instantiated by calling NewMuxServer().

--- a/tf6muxserver/mux_server.go
+++ b/tf6muxserver/mux_server.go
@@ -16,10 +16,8 @@ import (
 var _ tfprotov6.ProviderServer = &muxServer{}
 
 // Temporarily verify that v5tov6Server implements new RPCs correctly.
-// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
 // Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/219
 var (
-	_ tfprotov6.FunctionServer = &muxServer{}
 	//nolint:staticcheck // Intentional verification of interface implementation.
 	_ tfprotov6.ResourceServerWithMoveResourceState = &muxServer{}
 )

--- a/tf6muxserver/mux_server_CallFunction.go
+++ b/tf6muxserver/mux_server_CallFunction.go
@@ -47,23 +47,7 @@ func (s *muxServer) CallFunction(ctx context.Context, req *tfprotov6.CallFunctio
 
 	ctx = logging.Tfprotov6ProviderServerContext(ctx, server)
 
-	// Remove and call server.CallFunction below directly.
-	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-	functionServer, ok := server.(tfprotov6.FunctionServer)
-
-	if !ok {
-		resp := &tfprotov6.CallFunctionResponse{
-			Error: &tfprotov6.FunctionError{
-				Text: "Provider Functions Not Implemented: A provider-defined function call was received by the provider, however the provider does not implement functions. " +
-					"Either upgrade the provider to a version that implements provider-defined functions or this is a bug in Terraform that should be reported to the Terraform maintainers.",
-			},
-		}
-
-		return resp, nil
-	}
-
 	logging.MuxTrace(ctx, "calling downstream server")
 
-	// return server.CallFunction(ctx, req)
-	return functionServer.CallFunction(ctx, req)
+	return server.CallFunction(ctx, req)
 }

--- a/tf6muxserver/mux_server_CallFunction_test.go
+++ b/tf6muxserver/mux_server_CallFunction_test.go
@@ -39,15 +39,7 @@ func TestMuxServerCallFunction(t *testing.T) {
 		t.Fatalf("unexpected error setting up factory: %s", err)
 	}
 
-	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-	functionServer, ok := muxServer.ProviderServer().(tfprotov6.FunctionServer)
-
-	if !ok {
-		t.Fatal("muxServer should implement tfprotov6.FunctionServer")
-	}
-
-	// _, err = muxServer.ProviderServer().CallFunction(ctx, &tfprotov6.CallFunctionRequest{
-	_, err = functionServer.CallFunction(ctx, &tfprotov6.CallFunctionRequest{
+	_, err = muxServer.ProviderServer().CallFunction(ctx, &tfprotov6.CallFunctionRequest{
 		Name: "test_function1",
 	})
 
@@ -63,8 +55,7 @@ func TestMuxServerCallFunction(t *testing.T) {
 		t.Errorf("unexpected test_function1 CallFunction called on server2")
 	}
 
-	// _, err = muxServer.ProviderServer().CallFunction(ctx, &tfprotov6.CallFunctionRequest{
-	_, err = functionServer.CallFunction(ctx, &tfprotov6.CallFunctionRequest{
+	_, err = muxServer.ProviderServer().CallFunction(ctx, &tfprotov6.CallFunctionRequest{
 		Name: "test_function2",
 	})
 

--- a/tf6muxserver/mux_server_GetFunctions.go
+++ b/tf6muxserver/mux_server_GetFunctions.go
@@ -30,19 +30,9 @@ func (s *muxServer) GetFunctions(ctx context.Context, req *tfprotov6.GetFunction
 	for _, server := range s.servers {
 		ctx := logging.Tfprotov6ProviderServerContext(ctx, server)
 
-		// Remove and call server.GetFunctions below directly.
-		// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-		functionServer, ok := server.(tfprotov6.FunctionServer)
-
-		if !ok {
-			continue
-		}
-
 		logging.MuxTrace(ctx, "calling downstream server")
 
-		// serverResp, err := server.GetFunctions(ctx, &tfprotov6.GetFunctionsRequest{})
-		serverResp, err := functionServer.GetFunctions(ctx, &tfprotov6.GetFunctionsRequest{})
-
+		serverResp, err := server.GetFunctions(ctx, &tfprotov6.GetFunctionsRequest{})
 		if err != nil {
 			return resp, fmt.Errorf("error calling GetFunctions for %T: %w", server, err)
 		}

--- a/tf6muxserver/mux_server_GetFunctions_test.go
+++ b/tf6muxserver/mux_server_GetFunctions_test.go
@@ -311,15 +311,7 @@ func TestMuxServerGetFunctions(t *testing.T) {
 				t.Fatalf("unexpected error: %s", err)
 			}
 
-			// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-			functionServer, ok := muxServer.ProviderServer().(tfprotov6.FunctionServer)
-
-			if !ok {
-				t.Fatal("muxServer should implement tfprotov6.FunctionServer")
-			}
-
-			// resp, err := muxServer.ProviderServer().GetFunctions(context.Background(), &tfprotov6.GetFunctionsRequest{})
-			resp, err := functionServer.GetFunctions(context.Background(), &tfprotov6.GetFunctionsRequest{})
+			resp, err := muxServer.ProviderServer().GetFunctions(context.Background(), &tfprotov6.GetFunctionsRequest{})
 
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err)

--- a/tf6muxserver/mux_server_MoveResourceState.go
+++ b/tf6muxserver/mux_server_MoveResourceState.go
@@ -31,28 +31,7 @@ func (s *muxServer) MoveResourceState(ctx context.Context, req *tfprotov6.MoveRe
 
 	ctx = logging.Tfprotov6ProviderServerContext(ctx, server)
 
-	// Remove and call server.MoveResourceState below directly.
-	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/219
-	//nolint:staticcheck // Intentionally verifying interface implementation
-	resourceServer, ok := server.(tfprotov6.ResourceServerWithMoveResourceState)
-
-	if !ok {
-		resp := &tfprotov6.MoveResourceStateResponse{
-			Diagnostics: []*tfprotov6.Diagnostic{
-				{
-					Severity: tfprotov6.DiagnosticSeverityError,
-					Summary:  "MoveResourceState Not Implemented",
-					Detail: "A MoveResourceState call was received by the provider, however the provider does not implement MoveResourceState. " +
-						"Either upgrade the provider to a version that implements MoveResourceState or this is a bug in Terraform that should be reported to the Terraform maintainers.",
-				},
-			},
-		}
-
-		return resp, nil
-	}
-
 	logging.MuxTrace(ctx, "calling downstream server")
 
-	// return server.MoveResourceState(ctx, req)
-	return resourceServer.MoveResourceState(ctx, req)
+	return server.MoveResourceState(ctx, req)
 }

--- a/tf6muxserver/mux_server_MoveResourceState_test.go
+++ b/tf6muxserver/mux_server_MoveResourceState_test.go
@@ -39,16 +39,7 @@ func TestMuxServerMoveResourceState(t *testing.T) {
 		t.Fatalf("unexpected error setting up factory: %s", err)
 	}
 
-	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/219
-	//nolint:staticcheck // Intentionally verifying interface implementation
-	resourceServer, ok := muxServer.ProviderServer().(tfprotov6.ResourceServerWithMoveResourceState)
-
-	if !ok {
-		t.Fatal("muxServer should implement tfprotov6.ResourceServerWithMoveResourceState")
-	}
-
-	// _, err = muxServer.ProviderServer().MoveResourceState(ctx, &tfprotov6.MoveResourceStateRequest{
-	_, err = resourceServer.MoveResourceState(ctx, &tfprotov6.MoveResourceStateRequest{
+	_, err = muxServer.ProviderServer().MoveResourceState(ctx, &tfprotov6.MoveResourceStateRequest{
 		TargetTypeName: "test_resource1",
 	})
 
@@ -64,8 +55,7 @@ func TestMuxServerMoveResourceState(t *testing.T) {
 		t.Errorf("unexpected test_resource1 MoveResourceState called on server2")
 	}
 
-	// _, err = muxServer.ProviderServer().MoveResourceState(ctx, &tfprotov6.MoveResourceStateRequest{
-	_, err = resourceServer.MoveResourceState(ctx, &tfprotov6.MoveResourceStateRequest{
+	_, err = muxServer.ProviderServer().MoveResourceState(ctx, &tfprotov6.MoveResourceStateRequest{
 		TargetTypeName: "test_resource2",
 	})
 

--- a/tf6muxserver/mux_server_test.go
+++ b/tf6muxserver/mux_server_test.go
@@ -435,15 +435,7 @@ func TestMuxServerGetFunctionServer_GetProviderSchema(t *testing.T) {
 	terraformOp := func() {
 		defer wg.Done()
 
-		// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-		functionServer, ok := muxServer.ProviderServer().(tfprotov6.FunctionServer)
-
-		if !ok {
-			t.Error("muxServer should implement tfprotov6.FunctionServer")
-		}
-
-		//_, _ = muxServer.ProviderServer().CallFunction(ctx, &tfprotov6.CallFunctionRequest{
-		_, _ = functionServer.CallFunction(ctx, &tfprotov6.CallFunctionRequest{
+		_, _ = muxServer.ProviderServer().CallFunction(ctx, &tfprotov6.CallFunctionRequest{
 			Name: "test_function1",
 		})
 	}
@@ -502,15 +494,7 @@ func TestMuxServerGetFunctionServer_GetProviderSchema_Duplicate(t *testing.T) {
 	terraformOp := func() {
 		defer wg.Done()
 
-		// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-		functionServer, ok := muxServer.ProviderServer().(tfprotov6.FunctionServer)
-
-		if !ok {
-			t.Error("muxServer should implement tfprotov6.FunctionServer")
-		}
-
-		// resp, _ := muxServer.ProviderServer().CallFunction(ctx, &tfprotov6.CallFunctionRequest{
-		resp, _ := functionServer.CallFunction(ctx, &tfprotov6.CallFunctionRequest{
+		resp, _ := muxServer.ProviderServer().CallFunction(ctx, &tfprotov6.CallFunctionRequest{
 			Name: "test_function",
 		})
 
@@ -574,15 +558,7 @@ func TestMuxServerGetFunctionServer_GetMetadata(t *testing.T) {
 	terraformOp := func() {
 		defer wg.Done()
 
-		// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-		functionServer, ok := muxServer.ProviderServer().(tfprotov6.FunctionServer)
-
-		if !ok {
-			t.Error("muxServer should implement tfprotov6.FunctionServer")
-		}
-
-		// _, _ = muxServer.ProviderServer().CallFunction(ctx, &tfprotov6.CallFunctionRequest{
-		_, _ = functionServer.CallFunction(ctx, &tfprotov6.CallFunctionRequest{
+		_, _ = muxServer.ProviderServer().CallFunction(ctx, &tfprotov6.CallFunctionRequest{
 			Name: "test_function1",
 		})
 	}
@@ -645,15 +621,7 @@ func TestMuxServerGetFunctionServer_GetMetadata_Duplicate(t *testing.T) {
 	terraformOp := func() {
 		defer wg.Done()
 
-		// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-		functionServer, ok := muxServer.ProviderServer().(tfprotov6.FunctionServer)
-
-		if !ok {
-			t.Error("muxServer should implement tfprotov6.FunctionServer")
-		}
-
-		// resp, _ := muxServer.ProviderServer().CallFunction(ctx, &tfprotov6.CallFunctionRequest{
-		resp, _ := functionServer.CallFunction(ctx, &tfprotov6.CallFunctionRequest{
+		resp, _ := muxServer.ProviderServer().CallFunction(ctx, &tfprotov6.CallFunctionRequest{
 			Name: "test_function",
 		})
 
@@ -715,15 +683,7 @@ func TestMuxServerGetFunctionServer_GetMetadata_Partial(t *testing.T) {
 	terraformOp := func() {
 		defer wg.Done()
 
-		// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-		functionServer, ok := muxServer.ProviderServer().(tfprotov6.FunctionServer)
-
-		if !ok {
-			t.Error("muxServer should implement tfprotov6.FunctionServer")
-		}
-
-		// _, _ = muxServer.ProviderServer().CallFunction(ctx, &tfprotov6.CallFunctionRequest{
-		_, _ = functionServer.CallFunction(ctx, &tfprotov6.CallFunctionRequest{
+		_, _ = muxServer.ProviderServer().CallFunction(ctx, &tfprotov6.CallFunctionRequest{
 			Name: "test_function1",
 		})
 	}
@@ -785,15 +745,7 @@ func TestMuxServerGetFunctionServer_Missing(t *testing.T) {
 	terraformOp := func() {
 		defer wg.Done()
 
-		// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-		functionServer, ok := muxServer.ProviderServer().(tfprotov6.FunctionServer)
-
-		if !ok {
-			t.Error("muxServer should implement tfprotov6.FunctionServer")
-		}
-
-		//resp, _ := muxServer.ProviderServer().CallFunction(ctx, &tfprotov6.CallFunctionRequest{
-		resp, _ := functionServer.CallFunction(ctx, &tfprotov6.CallFunctionRequest{
+		resp, _ := muxServer.ProviderServer().CallFunction(ctx, &tfprotov6.CallFunctionRequest{
 			Name: "test_function_nonexistent",
 		})
 

--- a/tf6to5server/tf6to5server.go
+++ b/tf6to5server/tf6to5server.go
@@ -41,13 +41,6 @@ func DowngradeServer(ctx context.Context, v6server func() tfprotov6.ProviderServ
 
 var _ tfprotov5.ProviderServer = v6tov5Server{}
 
-// Temporarily verify that v6tov5Server implements new RPCs correctly.
-// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/219
-var (
-	//nolint:staticcheck // Intentional verification of interface implementation.
-	_ tfprotov5.ResourceServerWithMoveResourceState = v6tov5Server{}
-)
-
 type v6tov5Server struct {
 	v6Server tfprotov6.ProviderServer
 }
@@ -130,31 +123,9 @@ func (s v6tov5Server) ImportResourceState(ctx context.Context, req *tfprotov5.Im
 }
 
 func (s v6tov5Server) MoveResourceState(ctx context.Context, req *tfprotov5.MoveResourceStateRequest) (*tfprotov5.MoveResourceStateResponse, error) {
-	// Remove and call s.v6Server.MoveResourceState below directly.
-	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/219
-	//nolint:staticcheck // Intentional verification of interface implementation.
-	resourceServer, ok := s.v6Server.(tfprotov6.ResourceServerWithMoveResourceState)
-
-	if !ok {
-		v5Resp := &tfprotov5.MoveResourceStateResponse{
-			Diagnostics: []*tfprotov5.Diagnostic{
-				{
-					Severity: tfprotov5.DiagnosticSeverityError,
-					Summary:  "MoveResourceState Not Implemented",
-					Detail: "A MoveResourceState call was received by the provider, however the provider does not implement the RPC. " +
-						"Either upgrade the provider to a version that implements MoveResourceState or this is a bug in Terraform that should be reported to the Terraform maintainers.",
-				},
-			},
-		}
-
-		return v5Resp, nil
-	}
-
 	v6Req := tfprotov5tov6.MoveResourceStateRequest(req)
-	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/219
-	// v6Resp, err := s.v6Server.MoveResourceState(ctx, v6Req)
-	v6Resp, err := resourceServer.MoveResourceState(ctx, v6Req)
 
+	v6Resp, err := s.v6Server.MoveResourceState(ctx, v6Req)
 	if err != nil {
 		return nil, err
 	}

--- a/tf6to5server/tf6to5server.go
+++ b/tf6to5server/tf6to5server.go
@@ -42,10 +42,8 @@ func DowngradeServer(ctx context.Context, v6server func() tfprotov6.ProviderServ
 var _ tfprotov5.ProviderServer = v6tov5Server{}
 
 // Temporarily verify that v6tov5Server implements new RPCs correctly.
-// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
 // Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/219
 var (
-	_ tfprotov5.FunctionServer = v6tov5Server{}
 	//nolint:staticcheck // Intentional verification of interface implementation.
 	_ tfprotov5.ResourceServerWithMoveResourceState = v6tov5Server{}
 )
@@ -66,26 +64,9 @@ func (s v6tov5Server) ApplyResourceChange(ctx context.Context, req *tfprotov5.Ap
 }
 
 func (s v6tov5Server) CallFunction(ctx context.Context, req *tfprotov5.CallFunctionRequest) (*tfprotov5.CallFunctionResponse, error) {
-	// Remove and call s.v6Server.CallFunction below directly.
-	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-	functionServer, ok := s.v6Server.(tfprotov6.FunctionServer)
-
-	if !ok {
-		v5Resp := &tfprotov5.CallFunctionResponse{
-			Error: &tfprotov5.FunctionError{
-				Text: "Provider Functions Not Implemented: A provider-defined function call was received by the provider, however the provider does not implement functions. " +
-					"Either upgrade the provider to a version that implements provider-defined functions or this is a bug in Terraform that should be reported to the Terraform maintainers.",
-			},
-		}
-
-		return v5Resp, nil
-	}
-
 	v6Req := tfprotov5tov6.CallFunctionRequest(req)
-	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-	// v6Resp, err := s.v6Server.CallFunction(ctx, v6Req)
-	v6Resp, err := functionServer.CallFunction(ctx, v6Req)
 
+	v6Resp, err := s.v6Server.CallFunction(ctx, v6Req)
 	if err != nil {
 		return nil, err
 	}
@@ -105,23 +86,9 @@ func (s v6tov5Server) ConfigureProvider(ctx context.Context, req *tfprotov5.Conf
 }
 
 func (s v6tov5Server) GetFunctions(ctx context.Context, req *tfprotov5.GetFunctionsRequest) (*tfprotov5.GetFunctionsResponse, error) {
-	// Remove and call s.v6Server.GetFunctions below directly.
-	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-	functionServer, ok := s.v6Server.(tfprotov6.FunctionServer)
-
-	if !ok {
-		v5Resp := &tfprotov5.GetFunctionsResponse{
-			Functions: map[string]*tfprotov5.Function{},
-		}
-
-		return v5Resp, nil
-	}
-
 	v6Req := tfprotov5tov6.GetFunctionsRequest(req)
-	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-	// v6Resp, err := s.v6Server.GetFunctions(ctx, v6Req)
-	v6Resp, err := functionServer.GetFunctions(ctx, v6Req)
 
+	v6Resp, err := s.v6Server.GetFunctions(ctx, v6Req)
 	if err != nil {
 		return nil, err
 	}

--- a/tf6to5server/tf6to5server_test.go
+++ b/tf6to5server/tf6to5server_test.go
@@ -456,16 +456,7 @@ func TestV6ToV5ServerMoveResourceState(t *testing.T) {
 		t.Fatalf("unexpected error downgrading server: %s", err)
 	}
 
-	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/219
-	//nolint:staticcheck // Intentional verification of interface implementation.
-	resourceServer, ok := v5server.(tfprotov5.ResourceServerWithMoveResourceState)
-
-	if !ok {
-		t.Fatal("v5server should implement tfprotov5.ResourceServerWithMoveResourceState")
-	}
-
-	// _, err = v5server.MoveResourceState(ctx, &tfprotov5.MoveResourceStateRequest{
-	_, err = resourceServer.MoveResourceState(ctx, &tfprotov5.MoveResourceStateRequest{
+	_, err = v5server.MoveResourceState(ctx, &tfprotov5.MoveResourceStateRequest{
 		TargetTypeName: "test_resource",
 	})
 

--- a/tf6to5server/tf6to5server_test.go
+++ b/tf6to5server/tf6to5server_test.go
@@ -276,15 +276,7 @@ func TestV6ToV5ServerCallFunction(t *testing.T) {
 		t.Fatalf("unexpected error downgrading server: %s", err)
 	}
 
-	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-	functionServer, ok := v5server.(tfprotov5.FunctionServer)
-
-	if !ok {
-		t.Fatal("v5server should implement tfprotov5.FunctionServer")
-	}
-
-	// _, err = v5server.CallFunction(ctx, &tfprotov5.CallFunctionRequest{
-	_, err = functionServer.CallFunction(ctx, &tfprotov5.CallFunctionRequest{
+	_, err = v5server.CallFunction(ctx, &tfprotov5.CallFunctionRequest{
 		Name: "test_function",
 	})
 
@@ -344,15 +336,7 @@ func TestV5ToV6ServerGetFunctions(t *testing.T) {
 		t.Fatalf("unexpected error downgrading server: %s", err)
 	}
 
-	// Reference: https://github.com/hashicorp/terraform-plugin-mux/issues/210
-	functionServer, ok := v5server.(tfprotov5.FunctionServer)
-
-	if !ok {
-		t.Fatal("v5server should implement tfprotov5.FunctionServer")
-	}
-
-	//_, err = v5server.GetFunctions(ctx, &tfprotov5.GetFunctionsRequest{})
-	_, err = functionServer.GetFunctions(ctx, &tfprotov5.GetFunctionsRequest{})
+	_, err = v5server.GetFunctions(ctx, &tfprotov5.GetFunctionsRequest{})
 
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)


### PR DESCRIPTION
Closes #210 
Closes #219 

With the release of `terraform-plugin-go` [v0.23.0](https://github.com/hashicorp/terraform-plugin-go/releases/tag/v0.23.0), the `FunctionServer` interface and `MoveResourceState` method are now required. This PR removes the temporary type assertions.

I'm not sure if this warrants a changelog, but happy to add a `NOTE` if we think it's helpful.