### PR TITLE
internal: Add MoveResourceState capability to mux translations

### DIFF
--- a/internal/tfprotov5tov6/tfprotov5tov6.go
+++ b/internal/tfprotov5tov6/tfprotov5tov6.go
@@ -626,6 +626,7 @@ func ServerCapabilities(in *tfprotov5.ServerCapabilities) *tfprotov6.ServerCapab
 
 	return &tfprotov6.ServerCapabilities{
 		GetProviderSchemaOptional: in.GetProviderSchemaOptional,
+		MoveResourceState:         in.MoveResourceState,
 		PlanDestroy:               in.PlanDestroy,
 	}
 }

--- a/internal/tfprotov6tov5/tfprotov6tov5.go
+++ b/internal/tfprotov6tov5/tfprotov6tov5.go
@@ -702,6 +702,7 @@ func ServerCapabilities(in *tfprotov6.ServerCapabilities) *tfprotov5.ServerCapab
 
 	return &tfprotov5.ServerCapabilities{
 		GetProviderSchemaOptional: in.GetProviderSchemaOptional,
+		MoveResourceState:         in.MoveResourceState,
 		PlanDestroy:               in.PlanDestroy,
 	}
 }

--- a/tf5muxserver/mux_server_GetMetadata_test.go
+++ b/tf5muxserver/mux_server_GetMetadata_test.go
@@ -257,6 +257,7 @@ func TestMuxServerGetMetadata(t *testing.T) {
 						},
 						ServerCapabilities: &tfprotov5.ServerCapabilities{
 							GetProviderSchemaOptional: true,
+							MoveResourceState:         true,
 							PlanDestroy:               true,
 						},
 					},

--- a/tf5muxserver/mux_server_GetProviderSchema_test.go
+++ b/tf5muxserver/mux_server_GetProviderSchema_test.go
@@ -763,6 +763,7 @@ func TestMuxServerGetProviderSchema(t *testing.T) {
 						},
 						ServerCapabilities: &tfprotov5.ServerCapabilities{
 							GetProviderSchemaOptional: true,
+							MoveResourceState:         true,
 							PlanDestroy:               true,
 						},
 					},

--- a/tf6muxserver/mux_server_GetMetadata_test.go
+++ b/tf6muxserver/mux_server_GetMetadata_test.go
@@ -257,6 +257,7 @@ func TestMuxServerGetMetadata(t *testing.T) {
 						},
 						ServerCapabilities: &tfprotov6.ServerCapabilities{
 							GetProviderSchemaOptional: true,
+							MoveResourceState:         true,
 							PlanDestroy:               true,
 						},
 					},


### PR DESCRIPTION
This isn't actually fixing a bug, since muxed servers always return all client capabilities as true, but just for completeness since I was in the neighborhood 😆 

No changelog or release for this one