### PR TITLE
Add comments for UDR migration

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -1,5 +1,8 @@
 # Terraform Documentation
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 This directory contains the portions of [the Terraform website][terraform.io] that pertain to the Terraform Plugin Mux.
 
 The files in this directory are intended to be used in conjunction with

--- a/website/docs/plugin/mux/combining-protocol-version-5-providers.mdx
+++ b/website/docs/plugin/mux/combining-protocol-version-5-providers.mdx
@@ -4,6 +4,9 @@ description: >-
   Use the tf5muxserver package in terraform-plugin-mux to combine protocol version 5 providers.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Combining Protocol Version 5 Providers
 
 The [`tf5muxserver`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf5muxserver) package enables combining any number of [protocol version 5 provider servers](/terraform/plugin/how-terraform-works#protocol-version-5) into a single server.

--- a/website/docs/plugin/mux/combining-protocol-version-6-providers.mdx
+++ b/website/docs/plugin/mux/combining-protocol-version-6-providers.mdx
@@ -4,6 +4,9 @@ description: >-
   Use the tf6muxserver package in terraform-plugin-mux to combine protocol version 6 providers.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Combining Protocol Version 6 Providers
 
 The [`tf6muxserver`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf6muxserver) package enables combining any number of [protocol version 6 provider servers](/terraform/plugin/how-terraform-works#protocol-version-6) into a single server.

--- a/website/docs/plugin/mux/index.mdx
+++ b/website/docs/plugin/mux/index.mdx
@@ -4,6 +4,9 @@ description: >-
   Use terraform-plugin-mux to combine and translate providers. It minimizes code changes by wrapping existing provider servers.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Combining and Translating Providers
 
 The [terraform-plugin-mux](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux) Go module is a collection of Go packages for combining (multiplexing) and translating provider servers. It helps minimize provider code changes by wrapping existing provider servers. This functionality is based on the [Terraform Plugin Protocol](/terraform/plugin/how-terraform-works#terraform-plugin-protocol) and [`terraform-plugin-go`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go) provider servers.

--- a/website/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
+++ b/website/docs/plugin/mux/translating-protocol-version-5-to-6.mdx
@@ -4,6 +4,9 @@ description: >-
   Use the tf5to6server package in terraform-plugin-mux to translate protocol version 5 providers to protocol version 6.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Translating Protocol Version 5 to 6
 
 The [`tf5to6server`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf5to6server) package enables translating a [protocol version 5](/terraform/plugin/how-terraform-works#protocol-version-5)  provider server into a [protocol version 6](/terraform/plugin/how-terraform-works#protocol-version-6)  provider server.

--- a/website/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
+++ b/website/docs/plugin/mux/translating-protocol-version-6-to-5.mdx
@@ -4,6 +4,9 @@ description: >-
   Use the tf6to5server package in terraform-plugin-mux to translate protocol version 6 providers to protocol version 5.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Translating Protocol Version 6 to 5
 
 The [`tf6to5server`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf6to5server) package enables translating a [protocol version 6](/terraform/plugin/how-terraform-works#protocol-version-6)  provider server into a [protocol version 5](/terraform/plugin/how-terraform-works#protocol-version-5) provider server.


### PR DESCRIPTION
### Description

We are migrating the terraform-plugin-* documentation to a unified HashiCorp product documentation repository. As a result of this migration, the unified repo (web-unified-docs) will be the source of truth.

This PR adds a noticed to all existing MDX files in the original location so folks know where to contribute. We plan on deprecating and removing the files in /website.

This PR will be merged after docs have been migrated