### PR TITLE
chore: Add explicit terraform installation for tests

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -27,6 +27,7 @@ jobs:
     defaults:
       run:
         working-directory: terraform-provider-corner
+    name: terraform-provider-corner (Terraform ${{ matrix.terraform}})
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -37,11 +38,19 @@ jobs:
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_version: ${{ matrix.terraform }}
+          terraform_wrapper: false
       - run: go mod edit -replace=github.com/hashicorp/terraform-plugin-mux=../
       - run: go mod tidy
       - run: go test -v ./...
         env:
           TF_ACC: '1'
+    strategy:
+      fail-fast: false
+      matrix:
+        terraform: ${{ fromJSON(vars.TF_VERSIONS_PROTOCOL_V5) }}
   test:
     name: test (Go v${{ matrix.go-version }})
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -23,11 +23,11 @@ jobs:
           go-version-file: 'go.mod'
       - run: go mod download
       - uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
-  terraform-provider-corner:
+  terraform-provider-corner-tfprotov5:
     defaults:
       run:
         working-directory: terraform-provider-corner
-    name: terraform-provider-corner (Terraform ${{ matrix.terraform}})
+    name: terraform-provider-corner (tfprotov5 /Terraform ${{ matrix.terraform}})
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -44,13 +44,47 @@ jobs:
           terraform_wrapper: false
       - run: go mod edit -replace=github.com/hashicorp/terraform-plugin-mux=../
       - run: go mod tidy
-      - run: go test -v ./...
+      - run: go test -v ./internal/tf5muxprovider
+        env:
+          TF_ACC: '1'
+      - run: go test -v ./internal/tf6to5provider
         env:
           TF_ACC: '1'
     strategy:
       fail-fast: false
       matrix:
         terraform: ${{ fromJSON(vars.TF_VERSIONS_PROTOCOL_V5) }}
+  terraform-provider-corner-tfprotov6:
+    defaults:
+      run:
+        working-directory: terraform-provider-corner
+    name: terraform-provider-corner (tfprotov6 /Terraform ${{ matrix.terraform}})
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: terraform-provider-corner
+          repository: hashicorp/terraform-provider-corner
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_version: ${{ matrix.terraform }}
+          terraform_wrapper: false
+      - run: go mod edit -replace=github.com/hashicorp/terraform-plugin-mux=../
+      - run: go mod tidy
+      - run: go test -v ./internal/tf6muxprovider
+        env:
+          TF_ACC: '1'
+      - run: go test -v ./internal/tf5to6provider
+        env:
+          TF_ACC: '1'
+    strategy:
+      fail-fast: false
+      matrix:
+        terraform: ${{ fromJSON(vars.TF_VERSIONS_PROTOCOL_V6) }}
   test:
     name: test (Go v${{ matrix.go-version }})
     runs-on: ubuntu-latest


### PR DESCRIPTION
Previously, it was just using running a single test with the latest Terraform version that is installed on the machine.

It also adds both protov5 + protov6 runs, and the explicit targeting of the mux packages