### PR TITLE
chore: Update to use plugin-go alpha1 + allow goreleaser to handle pre-releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,5 +5,6 @@ builds:
 milestones:
   - close: true
 release:
+  prerelease: auto
   ids:
     - 'none'

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.7
 
 require (
 	github.com/google/go-cmp v0.7.0
-	github.com/hashicorp/terraform-plugin-go v0.26.1-0.20250313132633-b799d5c93127
+	github.com/hashicorp/terraform-plugin-go v0.27.0-alpha.1
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	google.golang.org/grpc v1.71.0
 )

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/hashicorp/go-plugin v1.6.3 h1:xgHB+ZUSYeuJi96WtxEjzi23uh7YQpznjGh0U0U
 github.com/hashicorp/go-plugin v1.6.3/go.mod h1:MRobyh+Wc/nYy1V4KAXUiYfzxoYhs7V1mlH1Z7iY2h0=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/terraform-plugin-go v0.26.1-0.20250313132633-b799d5c93127 h1:V7RFaz+LWQY/S8tiWLuVFQMigEoZOpCF2vv7FW83vVw=
-github.com/hashicorp/terraform-plugin-go v0.26.1-0.20250313132633-b799d5c93127/go.mod h1:MfDwS/KnIy2QzCwdRtuqIjZ23gpYa9Vm+Z8cFpx8qtU=
+github.com/hashicorp/terraform-plugin-go v0.27.0-alpha.1 h1:/IZFNUEafGnJGXRe2iNQQ+vtzEw/5qiD+gOxkFrNbi4=
+github.com/hashicorp/terraform-plugin-go v0.27.0-alpha.1/go.mod h1:Tf2HngbyKvovAlGXgBOVGm3EDvbNaN/StUaTXwrej4o=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=
 github.com/hashicorp/terraform-plugin-log v0.9.0/go.mod h1:rKL8egZQ/eXSyDqzLUuwUYLVdlYeamldAHSxjUFADow=
 github.com/hashicorp/terraform-registry-address v0.2.4 h1:JXu/zHB2Ymg/TGVCRu10XqNa4Sh2bWcqCNyKWjnCPJA=


### PR DESCRIPTION
This PR updates the dependency to the pre-release for plugin-go that supports resource identity, which will be the last PR to prep for a `terraform-plugin-mux@v0.19.0-alpha.1` pre-release.

It also includes a modification to the goreleaser file which I believe should automatically handle the GitHub release portion: https://goreleaser.com/customization/release/#github

It's not immediately clear from the documentation that if the pre-release is detected, that it will not mark it as latest, but the GitHub UI doesn't even let you do that.... so hopefully that works! 🤞🏻 