### PR TITLE
Update `terraform-plugin-go` and add changelogs for `v0.20.0` release

### DIFF
--- a/.changes/unreleased/BUG FIXES-20250521-151305.yaml
+++ b/.changes/unreleased/BUG FIXES-20250521-151305.yaml
@@ -1,0 +1,8 @@
+kind: BUG FIXES
+body: 'all: Fixed a bug where muxed provider servers were not enforced to implement `GetResourceIdentitySchemas`, which is
+    required by Terraform v1.12.1 in the scenario where at least one of the muxed provider servers supports identity. Before upgrading this dependency
+    the Go modules that support identity should also be upgraded to prevent confusing errors, which are: terraform-plugin-go@v0.28.0, terraform-plugin-framework@v1.15.0,
+    terraform-plugin-sdk/v2@v2.37.0, and terraform-plugin-testing@v1.13.0.'
+time: 2025-05-21T15:13:05.963451-04:00
+custom:
+    Issue: "307"

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.7
 
 require (
 	github.com/google/go-cmp v0.7.0
-	github.com/hashicorp/terraform-plugin-go v0.27.0
+	github.com/hashicorp/terraform-plugin-go v0.27.1-0.20250521190222-e4163ede0746
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	google.golang.org/grpc v1.72.1
 )

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.7
 
 require (
 	github.com/google/go-cmp v0.7.0
-	github.com/hashicorp/terraform-plugin-go v0.27.1-0.20250521190222-e4163ede0746
+	github.com/hashicorp/terraform-plugin-go v0.28.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	google.golang.org/grpc v1.72.1
 )

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/hashicorp/go-plugin v1.6.3 h1:xgHB+ZUSYeuJi96WtxEjzi23uh7YQpznjGh0U0U
 github.com/hashicorp/go-plugin v1.6.3/go.mod h1:MRobyh+Wc/nYy1V4KAXUiYfzxoYhs7V1mlH1Z7iY2h0=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/terraform-plugin-go v0.27.1-0.20250521190222-e4163ede0746 h1:Bzdpky/7WRDZBfxsktI97ZhUmZVxDzHGqb3jIcqvOIk=
-github.com/hashicorp/terraform-plugin-go v0.27.1-0.20250521190222-e4163ede0746/go.mod h1:FDa2Bb3uumkTGSkTFpWSOwWJDwA7bf3vdP3ltLDTH6o=
+github.com/hashicorp/terraform-plugin-go v0.28.0 h1:zJmu2UDwhVN0J+J20RE5huiF3XXlTYVIleaevHZgKPA=
+github.com/hashicorp/terraform-plugin-go v0.28.0/go.mod h1:FDa2Bb3uumkTGSkTFpWSOwWJDwA7bf3vdP3ltLDTH6o=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=
 github.com/hashicorp/terraform-plugin-log v0.9.0/go.mod h1:rKL8egZQ/eXSyDqzLUuwUYLVdlYeamldAHSxjUFADow=
 github.com/hashicorp/terraform-registry-address v0.2.5 h1:2GTftHqmUhVOeuu9CW3kwDkRe4pcBDq0uuK5VJngU1M=

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/hashicorp/go-plugin v1.6.3 h1:xgHB+ZUSYeuJi96WtxEjzi23uh7YQpznjGh0U0U
 github.com/hashicorp/go-plugin v1.6.3/go.mod h1:MRobyh+Wc/nYy1V4KAXUiYfzxoYhs7V1mlH1Z7iY2h0=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/terraform-plugin-go v0.27.0 h1:ujykws/fWIdsi6oTUT5Or4ukvEan4aN9lY+LOxVP8EE=
-github.com/hashicorp/terraform-plugin-go v0.27.0/go.mod h1:FDa2Bb3uumkTGSkTFpWSOwWJDwA7bf3vdP3ltLDTH6o=
+github.com/hashicorp/terraform-plugin-go v0.27.1-0.20250521190222-e4163ede0746 h1:Bzdpky/7WRDZBfxsktI97ZhUmZVxDzHGqb3jIcqvOIk=
+github.com/hashicorp/terraform-plugin-go v0.27.1-0.20250521190222-e4163ede0746/go.mod h1:FDa2Bb3uumkTGSkTFpWSOwWJDwA7bf3vdP3ltLDTH6o=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=
 github.com/hashicorp/terraform-plugin-log v0.9.0/go.mod h1:rKL8egZQ/eXSyDqzLUuwUYLVdlYeamldAHSxjUFADow=
 github.com/hashicorp/terraform-registry-address v0.2.5 h1:2GTftHqmUhVOeuu9CW3kwDkRe4pcBDq0uuK5VJngU1M=

--- a/tf5muxserver/mux_server_GetResourceIdentitySchemas.go
+++ b/tf5muxserver/mux_server_GetResourceIdentitySchemas.go
@@ -30,22 +30,7 @@ func (s *muxServer) GetResourceIdentitySchemas(ctx context.Context, req *tfproto
 		ctx := logging.Tfprotov5ProviderServerContext(ctx, server)
 		logging.MuxTrace(ctx, "calling downstream server")
 
-		// TODO: Remove and call server.GetResourceIdentitySchemas below directly once interface becomes required.
-		//nolint:staticcheck // Intentionally verifying interface implementation
-		resourceIdentityServer, ok := server.(tfprotov5.ProviderServerWithResourceIdentity)
-
-		if !ok {
-			resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
-				Severity: tfprotov5.DiagnosticSeverityError,
-				Summary:  "GetResourceIdentitySchemas Not Implemented",
-				Detail: "A GetResourceIdentitySchemas call was received by the provider, however the provider does not implement GetResourceIdentitySchemas. " +
-					"Either upgrade the provider to a version that implements GetResourceIdentitySchemas or this is a bug in Terraform that should be reported to the Terraform maintainers.",
-			})
-
-			continue
-		}
-
-		resourceIdentitySchemas, err := resourceIdentityServer.GetResourceIdentitySchemas(ctx, req)
+		resourceIdentitySchemas, err := server.GetResourceIdentitySchemas(ctx, req)
 
 		if err != nil {
 			return resp, fmt.Errorf("error calling GetResourceIdentitySchemas for %T: %w", server, err)

--- a/tf5muxserver/mux_server_GetResourceIdentitySchemas_test.go
+++ b/tf5muxserver/mux_server_GetResourceIdentitySchemas_test.go
@@ -345,13 +345,7 @@ func TestMuxServerGetResourceIdentitySchema(t *testing.T) {
 				t.Fatalf("unexpected error: %s", err)
 			}
 
-			//nolint:staticcheck // Intentionally verifying interface implementation
-			resourceIdentityServer, ok := muxServer.ProviderServer().(tfprotov5.ProviderServerWithResourceIdentity)
-			if !ok {
-				t.Fatal("muxServer should implement tfprotov5.ProviderServerWithResourceIdentity")
-			}
-
-			resp, err := resourceIdentityServer.GetResourceIdentitySchemas(context.Background(), &tfprotov5.GetResourceIdentitySchemasRequest{})
+			resp, err := muxServer.ProviderServer().GetResourceIdentitySchemas(context.Background(), &tfprotov5.GetResourceIdentitySchemasRequest{})
 
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err)

--- a/tf5muxserver/mux_server_UpgradeResourceIdentity.go
+++ b/tf5muxserver/mux_server_UpgradeResourceIdentity.go
@@ -30,26 +30,8 @@ func (s *muxServer) UpgradeResourceIdentity(ctx context.Context, req *tfprotov5.
 		}, nil
 	}
 
-	// TODO: Remove and call server.UpgradeResourceIdentity below directly once interface becomes required.
-	//nolint:staticcheck // Intentionally verifying interface implementation
-	resourceIdentityServer, ok := server.(tfprotov5.ProviderServerWithResourceIdentity)
-	if !ok {
-		resp := &tfprotov5.UpgradeResourceIdentityResponse{
-			Diagnostics: []*tfprotov5.Diagnostic{
-				{
-					Severity: tfprotov5.DiagnosticSeverityError,
-					Summary:  "UpgradeResourceIdentity Not Implemented",
-					Detail: "A UpgradeResourceIdentity call was received by the provider, however the provider does not implement UpgradeResourceIdentity. " +
-						"Either upgrade the provider to a version that implements UpgradeResourceIdentity or this is a bug in Terraform that should be reported to the Terraform maintainers.",
-				},
-			},
-		}
-
-		return resp, nil
-	}
-
 	ctx = logging.Tfprotov5ProviderServerContext(ctx, server)
 	logging.MuxTrace(ctx, "calling downstream server")
 
-	return resourceIdentityServer.UpgradeResourceIdentity(ctx, req)
+	return server.UpgradeResourceIdentity(ctx, req)
 }

--- a/tf5muxserver/mux_server_UpgradeResourceIdentity_test.go
+++ b/tf5muxserver/mux_server_UpgradeResourceIdentity_test.go
@@ -49,13 +49,7 @@ func TestMuxServerUpgradeResourceIdentity(t *testing.T) {
 		t.Fatalf("unexpected error setting up factory: %s", err)
 	}
 
-	//nolint:staticcheck // Intentionally verifying interface implementation
-	resourceIdentityServer, ok := muxServer.ProviderServer().(tfprotov5.ProviderServerWithResourceIdentity)
-	if !ok {
-		t.Fatal("muxServer should implement tfprotov5.ProviderServerWithEphemeralResources")
-	}
-
-	_, err = resourceIdentityServer.UpgradeResourceIdentity(ctx, &tfprotov5.UpgradeResourceIdentityRequest{
+	_, err = muxServer.ProviderServer().UpgradeResourceIdentity(ctx, &tfprotov5.UpgradeResourceIdentityRequest{
 		TypeName: "test_resource_server1",
 	})
 
@@ -71,7 +65,7 @@ func TestMuxServerUpgradeResourceIdentity(t *testing.T) {
 		t.Errorf("unexpected test_resource_server1 UpgradeResourceIdentity called on server2")
 	}
 
-	_, err = resourceIdentityServer.UpgradeResourceIdentity(ctx, &tfprotov5.UpgradeResourceIdentityRequest{
+	_, err = muxServer.ProviderServer().UpgradeResourceIdentity(ctx, &tfprotov5.UpgradeResourceIdentityRequest{
 		TypeName: "test_resource_server2",
 	})
 

--- a/tf5to6server/tf5to6server.go
+++ b/tf5to6server/tf5to6server.go
@@ -111,26 +111,9 @@ func (s v5tov6Server) GetProviderSchema(ctx context.Context, req *tfprotov6.GetP
 }
 
 func (s v5tov6Server) GetResourceIdentitySchemas(ctx context.Context, req *tfprotov6.GetResourceIdentitySchemasRequest) (*tfprotov6.GetResourceIdentitySchemasResponse, error) {
-	// TODO: Remove and call s.v6Server.GetResourceIdentitySchemas below directly once interface becomes required
-	//nolint:staticcheck // Intentionally verifying interface implementation
-	resourceIdentityServer, ok := s.v5Server.(tfprotov5.ProviderServerWithResourceIdentity)
-	if !ok {
-		v6Resp := &tfprotov6.GetResourceIdentitySchemasResponse{
-			Diagnostics: []*tfprotov6.Diagnostic{
-				{
-					Severity: tfprotov6.DiagnosticSeverityError,
-					Summary:  "GetResourceIdentitySchemas Not Implemented",
-					Detail: "A GetResourceIdentitySchemas call was received by the provider, however the provider does not implement the RPC. " +
-						"Either upgrade the provider to a version that implements GetResourceIdentitySchemas or this is a bug in Terraform that should be reported to the Terraform maintainers.",
-				},
-			},
-		}
-
-		return v6Resp, nil
-	}
 
 	v5Req := tfprotov6tov5.GetResourceIdentitySchemasRequest(req)
-	v5Resp, err := resourceIdentityServer.GetResourceIdentitySchemas(ctx, v5Req)
+	v5Resp, err := s.v5Server.GetResourceIdentitySchemas(ctx, v5Req)
 
 	if err != nil {
 		return nil, err
@@ -244,25 +227,8 @@ func (s v5tov6Server) UpgradeResourceState(ctx context.Context, req *tfprotov6.U
 }
 
 func (s v5tov6Server) UpgradeResourceIdentity(ctx context.Context, req *tfprotov6.UpgradeResourceIdentityRequest) (*tfprotov6.UpgradeResourceIdentityResponse, error) {
-	//nolint:staticcheck // Intentionally verifying interface implementation
-	resourceIdentityServer, ok := s.v5Server.(tfprotov5.ProviderServerWithResourceIdentity)
-	if !ok {
-		v6Resp := &tfprotov6.UpgradeResourceIdentityResponse{
-			Diagnostics: []*tfprotov6.Diagnostic{
-				{
-					Severity: tfprotov6.DiagnosticSeverityError,
-					Summary:  "UpgradeResourceIdentity Not Implemented",
-					Detail: "A UpgradeResourceIdentity call was received by the provider, however the provider does not implement the RPC. " +
-						"Either upgrade the provider to a version that implements UpgradeResourceIdentity or this is a bug in Terraform that should be reported to the Terraform maintainers.",
-				},
-			},
-		}
-
-		return v6Resp, nil
-	}
-
 	v5Req := tfprotov6tov5.UpgradeResourceIdentityRequest(req)
-	v5Resp, err := resourceIdentityServer.UpgradeResourceIdentity(ctx, v5Req)
+	v5Resp, err := s.v5Server.UpgradeResourceIdentity(ctx, v5Req)
 
 	if err != nil {
 		return nil, err

--- a/tf5to6server/tf5to6server_test.go
+++ b/tf5to6server/tf5to6server_test.go
@@ -356,13 +356,7 @@ func TestV6ToV5ServerGetResourceIdentitySchemas(t *testing.T) {
 		t.Fatalf("unexpected error downgrading server: %s", err)
 	}
 
-	//nolint:staticcheck // Intentionally verifying interface implementation
-	resourceIdentityServer, ok := v6server.(tfprotov6.ProviderServerWithResourceIdentity)
-	if !ok {
-		t.Fatal("v6server should implement tfprotov6.ProviderServerWithResourceIdentity")
-	}
-
-	_, err = resourceIdentityServer.GetResourceIdentitySchemas(ctx, &tfprotov6.GetResourceIdentitySchemasRequest{})
+	_, err = v6server.GetResourceIdentitySchemas(ctx, &tfprotov6.GetResourceIdentitySchemasRequest{})
 
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -668,13 +662,7 @@ func TestV6ToV5ServerUpgradeResourceIdentity(t *testing.T) {
 		t.Fatalf("unexpected error downgrading server: %s", err)
 	}
 
-	//nolint:staticcheck // Intentionally verifying interface implementation
-	resourceIdentityServer, ok := v6server.(tfprotov6.ProviderServerWithResourceIdentity)
-	if !ok {
-		t.Fatal("v6server should implement tfprotov6.ProviderServerWithResourceIdentity")
-	}
-
-	_, err = resourceIdentityServer.UpgradeResourceIdentity(ctx, &tfprotov6.UpgradeResourceIdentityRequest{
+	_, err = v6server.UpgradeResourceIdentity(ctx, &tfprotov6.UpgradeResourceIdentityRequest{
 		TypeName: "test_resource",
 	})
 

--- a/tf6muxserver/mux_server_GetResourceIdentitySchemas.go
+++ b/tf6muxserver/mux_server_GetResourceIdentitySchemas.go
@@ -30,22 +30,7 @@ func (s *muxServer) GetResourceIdentitySchemas(ctx context.Context, req *tfproto
 		ctx := logging.Tfprotov6ProviderServerContext(ctx, server)
 		logging.MuxTrace(ctx, "calling downstream server")
 
-		// TODO: Remove and call server.GetResourceIdentitySchemas below directly once interface becomes required.
-		//nolint:staticcheck // Intentionally verifying interface implementation
-		resourceIdentityServer, ok := server.(tfprotov6.ProviderServerWithResourceIdentity)
-
-		if !ok {
-			resp.Diagnostics = append(resp.Diagnostics, &tfprotov6.Diagnostic{
-				Severity: tfprotov6.DiagnosticSeverityError,
-				Summary:  "GetResourceIdentitySchemas Not Implemented",
-				Detail: "A GetResourceIdentitySchemas call was received by the provider, however the provider does not implement GetResourceIdentitySchemas. " +
-					"Either upgrade the provider to a version that implements GetResourceIdentitySchemas or this is a bug in Terraform that should be reported to the Terraform maintainers.",
-			})
-
-			continue
-		}
-
-		resourceIdentitySchemas, err := resourceIdentityServer.GetResourceIdentitySchemas(ctx, req)
+		resourceIdentitySchemas, err := server.GetResourceIdentitySchemas(ctx, req)
 
 		if err != nil {
 			return resp, fmt.Errorf("error calling GetResourceIdentitySchemas for %T: %w", server, err)

--- a/tf6muxserver/mux_server_GetResourceIdentitySchemas_test.go
+++ b/tf6muxserver/mux_server_GetResourceIdentitySchemas_test.go
@@ -345,13 +345,7 @@ func TestMuxServerGetResourceIdentitySchema(t *testing.T) {
 				t.Fatalf("unexpected error: %s", err)
 			}
 
-			//nolint:staticcheck // Intentionally verifying interface implementation
-			resourceIdentityServer, ok := muxServer.ProviderServer().(tfprotov6.ProviderServerWithResourceIdentity)
-			if !ok {
-				t.Fatal("muxServer should implement tfprotov6.ProviderServerWithResourceIdentity")
-			}
-
-			resp, err := resourceIdentityServer.GetResourceIdentitySchemas(context.Background(), &tfprotov6.GetResourceIdentitySchemasRequest{})
+			resp, err := muxServer.ProviderServer().GetResourceIdentitySchemas(context.Background(), &tfprotov6.GetResourceIdentitySchemasRequest{})
 
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err)

--- a/tf6muxserver/mux_server_UpgradeResourceIdentity.go
+++ b/tf6muxserver/mux_server_UpgradeResourceIdentity.go
@@ -30,26 +30,8 @@ func (s *muxServer) UpgradeResourceIdentity(ctx context.Context, req *tfprotov6.
 		}, nil
 	}
 
-	// TODO: Remove and call server.UpgradeResourceIdentity below directly once interface becomes required.
-	//nolint:staticcheck // Intentionally verifying interface implementation
-	resourceIdentityServer, ok := server.(tfprotov6.ProviderServerWithResourceIdentity)
-	if !ok {
-		resp := &tfprotov6.UpgradeResourceIdentityResponse{
-			Diagnostics: []*tfprotov6.Diagnostic{
-				{
-					Severity: tfprotov6.DiagnosticSeverityError,
-					Summary:  "UpgradeResourceIdentity Not Implemented",
-					Detail: "A UpgradeResourceIdentity call was received by the provider, however the provider does not implement UpgradeResourceIdentity. " +
-						"Either upgrade the provider to a version that implements UpgradeResourceIdentity or this is a bug in Terraform that should be reported to the Terraform maintainers.",
-				},
-			},
-		}
-
-		return resp, nil
-	}
-
 	ctx = logging.Tfprotov6ProviderServerContext(ctx, server)
 	logging.MuxTrace(ctx, "calling downstream server")
 
-	return resourceIdentityServer.UpgradeResourceIdentity(ctx, req)
+	return server.UpgradeResourceIdentity(ctx, req)
 }

--- a/tf6muxserver/mux_server_UpgradeResourceIdentity_test.go
+++ b/tf6muxserver/mux_server_UpgradeResourceIdentity_test.go
@@ -49,13 +49,7 @@ func TestMuxServerUpgradeResourceIdentity(t *testing.T) {
 		t.Fatalf("unexpected error setting up factory: %s", err)
 	}
 
-	//nolint:staticcheck // Intentionally verifying interface implementation
-	resourceIdentityServer, ok := muxServer.ProviderServer().(tfprotov6.ProviderServerWithResourceIdentity)
-	if !ok {
-		t.Fatal("muxServer should implement tfprotov6.ProviderServerWithEphemeralResources")
-	}
-
-	_, err = resourceIdentityServer.UpgradeResourceIdentity(ctx, &tfprotov6.UpgradeResourceIdentityRequest{
+	_, err = muxServer.ProviderServer().UpgradeResourceIdentity(ctx, &tfprotov6.UpgradeResourceIdentityRequest{
 		TypeName: "test_resource_server1",
 	})
 
@@ -71,7 +65,7 @@ func TestMuxServerUpgradeResourceIdentity(t *testing.T) {
 		t.Errorf("unexpected test_resource_server1 UpgradeResourceIdentity called on server2")
 	}
 
-	_, err = resourceIdentityServer.UpgradeResourceIdentity(ctx, &tfprotov6.UpgradeResourceIdentityRequest{
+	_, err = muxServer.ProviderServer().UpgradeResourceIdentity(ctx, &tfprotov6.UpgradeResourceIdentityRequest{
 		TypeName: "test_resource_server2",
 	})
 

--- a/tf6to5server/tf6to5server.go
+++ b/tf6to5server/tf6to5server.go
@@ -123,26 +123,8 @@ func (s v6tov5Server) GetProviderSchema(ctx context.Context, req *tfprotov5.GetP
 }
 
 func (s v6tov5Server) GetResourceIdentitySchemas(ctx context.Context, req *tfprotov5.GetResourceIdentitySchemasRequest) (*tfprotov5.GetResourceIdentitySchemasResponse, error) {
-	// TODO: Remove and call s.v6Server.GetResourceIdentitySchemas below directly once interface becomes required
-	//nolint:staticcheck // Intentionally verifying interface implementation
-	resourceIdentityServer, ok := s.v6Server.(tfprotov6.ProviderServerWithResourceIdentity)
-	if !ok {
-		v5Resp := &tfprotov5.GetResourceIdentitySchemasResponse{
-			Diagnostics: []*tfprotov5.Diagnostic{
-				{
-					Severity: tfprotov5.DiagnosticSeverityError,
-					Summary:  "GetResourceIdentitySchemas Not Implemented",
-					Detail: "A GetResourceIdentitySchemas call was received by the provider, however the provider does not implement the RPC. " +
-						"Either upgrade the provider to a version that implements GetResourceIdentitySchemas or this is a bug in Terraform that should be reported to the Terraform maintainers.",
-				},
-			},
-		}
-
-		return v5Resp, nil
-	}
-
 	v6Req := tfprotov5tov6.GetResourceIdentitySchemasRequest(req)
-	v6Resp, err := resourceIdentityServer.GetResourceIdentitySchemas(ctx, v6Req)
+	v6Resp, err := s.v6Server.GetResourceIdentitySchemas(ctx, v6Req)
 
 	if err != nil {
 		return nil, err
@@ -267,26 +249,8 @@ func (s v6tov5Server) UpgradeResourceState(ctx context.Context, req *tfprotov5.U
 }
 
 func (s v6tov5Server) UpgradeResourceIdentity(ctx context.Context, req *tfprotov5.UpgradeResourceIdentityRequest) (*tfprotov5.UpgradeResourceIdentityResponse, error) {
-	// TODO: Remove and call s.v6Server.UpgradeResourceIdentity below directly once interface becomes required
-	//nolint:staticcheck // Intentionally verifying interface implementation
-	resourceIdentityServer, ok := s.v6Server.(tfprotov6.ProviderServerWithResourceIdentity)
-	if !ok {
-		v5Resp := &tfprotov5.UpgradeResourceIdentityResponse{
-			Diagnostics: []*tfprotov5.Diagnostic{
-				{
-					Severity: tfprotov5.DiagnosticSeverityError,
-					Summary:  "UpgradeResourceIdentity Not Implemented",
-					Detail: "A UpgradeResourceIdentity call was received by the provider, however the provider does not implement the RPC. " +
-						"Either upgrade the provider to a version that implements UpgradeResourceIdentity or this is a bug in Terraform that should be reported to the Terraform maintainers.",
-				},
-			},
-		}
-
-		return v5Resp, nil
-	}
-
 	v6Req := tfprotov5tov6.UpgradeResourceIdentityRequest(req)
-	v6Resp, err := resourceIdentityServer.UpgradeResourceIdentity(ctx, v6Req)
+	v6Resp, err := s.v6Server.UpgradeResourceIdentity(ctx, v6Req)
 
 	if err != nil {
 		return nil, err

--- a/tf6to5server/tf6to5server_test.go
+++ b/tf6to5server/tf6to5server_test.go
@@ -454,13 +454,7 @@ func TestV6ToV5ServerGetResourceIdentitySchemas(t *testing.T) {
 		t.Fatalf("unexpected error downgrading server: %s", err)
 	}
 
-	//nolint:staticcheck // Intentionally verifying interface implementation
-	resourceIdentityServer, ok := v5server.(tfprotov5.ProviderServerWithResourceIdentity)
-	if !ok {
-		t.Fatal("v5server should implement tfprotov5.ProviderServerWithResourceIdentity")
-	}
-
-	_, err = resourceIdentityServer.GetResourceIdentitySchemas(ctx, &tfprotov5.GetResourceIdentitySchemasRequest{})
+	_, err = v5server.GetResourceIdentitySchemas(ctx, &tfprotov5.GetResourceIdentitySchemasRequest{})
 
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -795,13 +789,7 @@ func TestV6ToV5ServerUpgradeResourceIdentity(t *testing.T) {
 		t.Fatalf("unexpected error downgrading server: %s", err)
 	}
 
-	//nolint:staticcheck // Intentionally verifying interface implementation
-	resourceIdentityServer, ok := v5server.(tfprotov5.ProviderServerWithResourceIdentity)
-	if !ok {
-		t.Fatal("v5server should implement tfprotov5.ProviderServerWithResourceIdentity")
-	}
-
-	_, err = resourceIdentityServer.UpgradeResourceIdentity(ctx, &tfprotov5.UpgradeResourceIdentityRequest{
+	_, err = v5server.UpgradeResourceIdentity(ctx, &tfprotov5.UpgradeResourceIdentityRequest{
 		TypeName: "test_resource",
 	})
 


### PR DESCRIPTION
## Related Issue

Closes #279 

Ref: https://github.com/hashicorp/terraform-plugin-go/pull/516

## Description

This removes the temporary interface that is removed in `terraform-plugin-go@v0.28.0`

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

N/A
