### PR TITLE
experimental: what if - interceptors

### DIFF
--- a/tf5muxserver/mux_server.go
+++ b/tf5muxserver/mux_server.go
@@ -55,6 +55,19 @@ type muxServer struct {
 
 	// Underlying servers for requests that should be handled by all servers
 	servers []tfprotov5.ProviderServer
+
+	// interceptors []tfprotov5.Interceptor
+	listResourceInterceptors []Interceptor[*tfprotov5.ListResourceRequest]
+}
+
+type Event byte
+
+const (
+	Before Event = iota
+)
+
+type Interceptor[T any] interface {
+	Call(ctx context.Context, e Event, request T) (newContext context.Context, newRequest T)
 }
 
 // ProviderServer is a function compatible with tf6server.Serve.

--- a/tf5muxserver/mux_server_ListResource.go
+++ b/tf5muxserver/mux_server_ListResource.go
@@ -17,6 +17,10 @@ func (s *muxServer) ListResource(ctx context.Context, req *tfprotov5.ListResourc
 	ctx = logging.InitContext(ctx)
 	ctx = logging.RpcContext(ctx, rpc)
 
+	for _, i := range s.listResourceInterceptors {
+		ctx, req = i.Call(ctx, Before, req)
+	}
+
 	server, diags, err := s.getListResourceServer(ctx, req.TypeName)
 
 	if err != nil {


### PR DESCRIPTION
## Description

The ongoing `experimental` theme: I "think" by trying things & sharing them 😃

This pull request proposes a way for a logical provider to "intercept" a request to a muxed server so that it can modify the context or the request.

As an example, we'll consider a combined SDK+Framework provider, with a List Resource in the Framework logical provider and a Resource in the SDK logical provider. When mux handles a `ListResource` request, the SDK provider has an opportunity to decorate the context with Resource "stuff" – a schema map or even a `schema.Resource`. The List Resource in the Framework logical provider can use this Resource "stuff" to interact with existing provider logic.

And mux and Framework remain blissfully decoupled from SDK. 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None.