### PR TITLE
tf5to6server: add ProtoV5 to 6 schema translators

### DIFF
--- a/tf5to6server/translate/translate.go
+++ b/tf5to6server/translate/translate.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2020, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package translate
 
 import (

--- a/tf5to6server/translate/translate.go
+++ b/tf5to6server/translate/translate.go
@@ -1,0 +1,15 @@
+package translate
+
+import (
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-mux/internal/tfprotov5tov6"
+)
+
+func Schema(in *tfprotov5.Schema) *tfprotov6.Schema {
+	return tfprotov5tov6.Schema(in)
+}
+
+func ResourceIdentitySchema(in *tfprotov5.ResourceIdentitySchema) *tfprotov6.ResourceIdentitySchema {
+	return tfprotov5tov6.ResourceIdentitySchema(in)
+}


### PR DESCRIPTION
## Related Issue

https://github.com/hashicorp/terraform-plugin-framework/issues/1279

## Description

This PR adds exported `Schema` and `ResourceIdentitySchema` methods for muxed ProtoV6 providers to translate ProtoV5 schemas from SDKv2 into ProtoV6 schemas.

Usage in a Plugin Framework `RawV6Schemas` implementation:

```go
func (r *ListResource) RawV6Schemas(ctx context.Context, req list.RawV6SchemaRequest, resp *list.Raw65SchemaResponse) {
	thingResource := ResourceVPC()

	resp.ProtoV6Schema = translate.Schema(thingResource.ProtoSchema(ctx)())
	resp.ProtoV6IdentitySchema = translate.ResourceIdentitySchema(thingResource.ProtoIdentitySchema(ctx)())
}
```


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None.