### PR TITLE
add note about upgrading other deps to changelog of 0.23.0

### DIFF
--- a/.changes/0.23.0.md
+++ b/.changes/0.23.0.md
@@ -3,6 +3,7 @@
 NOTES:
 
 * This Go module has been updated to Go 1.25 per the [Go support policy](https://golang.org/doc/devel/release.html#policy). Any consumers building on earlier Go versions may experience errors. ([#355](https://github.com/hashicorp/terraform-plugin-mux/issues/355))
+* all: To prevent compilation errors, ensure your Go module is updated to at least terraform-plugin-framework@v1.19.0, terraform-plugin-go@v0.31.1, terraform-plugin-sdk/v2@v2.40.0, and terraform-plugin-testing@v1.15.0 before upgrading this dependency. (#607)
 
 FEATURES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 NOTES:
 
 * This Go module has been updated to Go 1.25 per the [Go support policy](https://golang.org/doc/devel/release.html#policy). Any consumers building on earlier Go versions may experience errors. ([#355](https://github.com/hashicorp/terraform-plugin-mux/issues/355))
+* all: To prevent compilation errors, ensure your Go module is updated to at least terraform-plugin-framework@v1.19.0, terraform-plugin-go@v0.31.1, terraform-plugin-sdk/v2@v2.40.0, and terraform-plugin-testing@v1.15.0 before upgrading this dependency. (#607)
 
 FEATURES:
 


### PR DESCRIPTION
## Related Issue

Related to https://github.com/hashicorp/terraform-plugin-mux/pull/350#issuecomment-4175373820 <!-- INSERT ISSUE NUMBER -->

## Description

After merging this, the existing Github release needs to be manually updated with the added changelog line.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
